### PR TITLE
Allow notices without links to the FR

### DIFF
--- a/regcore/migrations/0009_auto__chg_field_notice_fr_url.py
+++ b/regcore/migrations/0009_auto__chg_field_notice_fr_url.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'Notice.fr_url'
+        db.alter_column(u'regcore_notice', 'fr_url', self.gf('django.db.models.fields.CharField')(max_length=200, null=True))
+
+    def backwards(self, orm):
+
+        # Changing field 'Notice.fr_url'
+        db.alter_column(u'regcore_notice', 'fr_url', self.gf('django.db.models.fields.CharField')(default='', max_length=200))
+
+    models = {
+        u'regcore.diff': {
+            'Meta': {'unique_together': "(('label', 'old_version', 'new_version'),)", 'object_name': 'Diff', 'index_together': "(('label', 'old_version', 'new_version'),)"},
+            'diff': ('regcore.fields.CompressedJSONField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'new_version': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
+            'old_version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
+        },
+        u'regcore.layer': {
+            'Meta': {'unique_together': "(('version', 'name', 'label'),)", 'object_name': 'Layer', 'index_together': "(('version', 'name', 'label'),)"},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'layer': ('regcore.fields.CompressedJSONField', [], {}),
+            'name': ('django.db.models.fields.SlugField', [], {'max_length': '20'}),
+            'version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
+        },
+        u'regcore.notice': {
+            'Meta': {'object_name': 'Notice'},
+            'document_number': ('django.db.models.fields.SlugField', [], {'max_length': '20', 'primary_key': 'True'}),
+            'effective_on': ('django.db.models.fields.DateField', [], {'null': 'True'}),
+            'fr_url': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True'}),
+            'notice': ('regcore.fields.CompressedJSONField', [], {}),
+            'publication_date': ('django.db.models.fields.DateField', [], {})
+        },
+        u'regcore.noticecfrpart': {
+            'Meta': {'unique_together': "(('notice', 'cfr_part'),)", 'object_name': 'NoticeCFRPart', 'index_together': "(('notice', 'cfr_part'),)"},
+            'cfr_part': ('django.db.models.fields.SlugField', [], {'max_length': '10'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'notice': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['regcore.Notice']"})
+        },
+        u'regcore.regulation': {
+            'Meta': {'unique_together': "(('version', 'label_string'),)", 'object_name': 'Regulation', 'index_together': "(('version', 'label_string'),)"},
+            'children': ('regcore.fields.CompressedJSONField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label_string': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'node_type': ('django.db.models.fields.SlugField', [], {'max_length': '10'}),
+            'root': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {}),
+            'title': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'version': ('django.db.models.fields.SlugField', [], {'max_length': '20'})
+        }
+    }
+
+    complete_apps = ['regcore']

--- a/regcore/models.py
+++ b/regcore/models.py
@@ -31,7 +31,7 @@ class Layer(models.Model):
 class Notice(models.Model):
     document_number = models.SlugField(max_length=20, primary_key=True)
     effective_on = models.DateField(null=True)
-    fr_url = models.CharField(max_length=200)
+    fr_url = models.CharField(max_length=200, null=True)
     publication_date = models.DateField()
     notice = CompressedJSONField()
 


### PR DESCRIPTION
For https://github.com/18F/regulations-parser/issues/32, this allows notices to not have an FR url. This will be the case when a regulation hasn't changed since before federalregister.gov made the notices available in electronic form.
