### PR TITLE
Add a basic auth layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-    - "2.6"
     - "2.7"
 install: 
     - pip install -r requirements.txt

--- a/regcore/settings/base.py
+++ b/regcore/settings/base.py
@@ -73,6 +73,10 @@ LOGGING = {
     }
 }
 
+_envvars = ('HTTP_AUTH_USER', 'HTTP_AUTH_PASSWORD')
+for var in _envvars:
+    globals()[var] = os.environ.get(var)
+
 try:
     from local_settings import *
 except ImportError:

--- a/regcore_write/tests/views_security_tests.py
+++ b/regcore_write/tests/views_security_tests.py
@@ -1,0 +1,43 @@
+import base64
+
+from django.http import HttpResponse
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django.test.utils import override_settings
+
+from regcore_write.views import security
+
+
+def _wrapped_fn(request):
+    return HttpResponse(status=204)
+
+
+def _encode(username, password):
+    encoded = base64.b64encode('{}:{}'.format(username, password))
+    return 'Basic ' + encoded
+
+
+class SecurityTest(TestCase):
+    @override_settings(HTTP_AUTH_USER="a_user", HTTP_AUTH_PASSWORD="a_pass")
+    def test_basic_auth(self):
+        """Basic Auth must match the configuration"""
+        fn = security.basic_auth(_wrapped_fn)
+
+        request = RequestFactory().get('/')
+        self.assertEqual(fn(request).status_code, 401)
+
+        request = RequestFactory().get(
+            '/', HTTP_AUTHORIZATION=_encode('wrong', 'pass'))
+        self.assertEqual(fn(request).status_code, 401)
+
+        request = RequestFactory().get(
+            '/', HTTP_AUTHORIZATION=_encode('a_user', 'pass'))
+        self.assertEqual(fn(request).status_code, 401)
+
+        request = RequestFactory().get(
+            '/', HTTP_AUTHORIZATION=_encode('wrong', 'a_pass'))
+        self.assertEqual(fn(request).status_code, 401)
+
+        request = RequestFactory().get(
+            '/', HTTP_AUTHORIZATION=_encode('a_user', 'a_pass'))
+        self.assertEqual(fn(request).status_code, 204)

--- a/regcore_write/tests/views_security_tests.py
+++ b/regcore_write/tests/views_security_tests.py
@@ -19,9 +19,9 @@ def _encode(username, password):
 
 class SecurityTest(TestCase):
     @override_settings(HTTP_AUTH_USER="a_user", HTTP_AUTH_PASSWORD="a_pass")
-    def test_basic_auth(self):
+    def test_secure_write(self):
         """Basic Auth must match the configuration"""
-        fn = security.basic_auth(_wrapped_fn)
+        fn = security.secure_write(_wrapped_fn)
 
         request = RequestFactory().get('/')
         self.assertEqual(fn(request).status_code, 401)
@@ -40,4 +40,18 @@ class SecurityTest(TestCase):
 
         request = RequestFactory().get(
             '/', HTTP_AUTHORIZATION=_encode('a_user', 'a_pass'))
+        self.assertEqual(fn(request).status_code, 204)
+
+    @override_settings(HTTP_AUTH_USER=None, HTTP_AUTH_PASSWORD=None)
+    def test_secure_write_unset(self):
+        """Basic Auth should not be required when the environment isn't set"""
+        fn = security.secure_write(_wrapped_fn)
+        request = RequestFactory().get('/')
+        self.assertEqual(fn(request).status_code, 204)
+
+    @override_settings(HTTP_AUTH_USER="", HTTP_AUTH_PASSWORD="")
+    def test_secure_write_empty(self):
+        """Basic Auth should not be required when the environment is empty"""
+        fn = security.secure_write(_wrapped_fn)
+        request = RequestFactory().get('/')
         self.assertEqual(fn(request).status_code, 204)

--- a/regcore_write/views/diff.py
+++ b/regcore_write/views/diff.py
@@ -1,11 +1,11 @@
 import anyjson
-from django.views.decorators.csrf import csrf_exempt
 
 from regcore import db
 from regcore.responses import success, user_error
+from regcore_write.views.security import secure_write
 
 
-@csrf_exempt
+@secure_write
 def add(request, label_id, old_version, new_version):
     """Add the diff to the db, indexed by the label and versions"""
     try:

--- a/regcore_write/views/layer.py
+++ b/regcore_write/views/layer.py
@@ -1,8 +1,8 @@
 import anyjson
-from django.views.decorators.csrf import csrf_exempt
 
 from regcore import db
 from regcore.responses import success, user_error
+from regcore_write.views.security import secure_write
 
 
 def child_label_of(lhs, rhs):
@@ -21,7 +21,7 @@ def child_label_of(lhs, rhs):
     return False
 
 
-@csrf_exempt
+@secure_write
 def add(request, name, label_id, version):
     """Add the layer node and all of its children to the db"""
     try:

--- a/regcore_write/views/notice.py
+++ b/regcore_write/views/notice.py
@@ -1,11 +1,11 @@
 import anyjson
-from django.views.decorators.csrf import csrf_exempt
 
 from regcore import db
 from regcore.responses import success, user_error
+from regcore_write.views.security import secure_write
 
 
-@csrf_exempt
+@secure_write
 def add(request, docnum):
     """Add the notice to the db"""
     try:

--- a/regcore_write/views/regulation.py
+++ b/regcore_write/views/regulation.py
@@ -1,11 +1,11 @@
 import logging
 
 import anyjson
-from django.views.decorators.csrf import csrf_exempt
 import jsonschema
 
 from regcore import db
 from regcore.responses import success, user_error
+from regcore_write.views.security import secure_write
 
 
 #   This JSON schema is used to validate the regulation data provided
@@ -32,7 +32,7 @@ REGULATION_SCHEMA = {
 }
 
 
-@csrf_exempt
+@secure_write
 def add(request, label_id, version):
     """Add this regulation node and all of its children to the db"""
     try:

--- a/regcore_write/views/security.py
+++ b/regcore_write/views/security.py
@@ -39,9 +39,7 @@ def secure_write(func):
     """Depending on configuration, wrap each request in the appropriate
     security checks"""
     func = csrf_exempt(func)
-    enable_auth = (hasattr(settings, 'HTTP_AUTH_USER') and
-                   hasattr(settings, 'HTTP_AUTH_PASSWORD'))
-    if enable_auth:
+    if settings.HTTP_AUTH_USER and settings.HTTP_AUTH_PASSWORD:
         func = basic_auth(func)
 
     return func

--- a/regcore_write/views/security.py
+++ b/regcore_write/views/security.py
@@ -1,0 +1,47 @@
+import base64
+from functools import wraps
+
+from django.conf import settings
+from django.http import HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+
+
+def _not_authorized():
+    """User failed authorization"""
+    response = HttpResponse('Bad Authorization', status=401)
+    response['WWW-Authenticate'] = 'Basic realm="write access"'
+    return response
+
+
+def _basic_auth_str():
+    """Encode the configured auth username/password as a base64 string"""
+    user, password = settings.HTTP_AUTH_USER, settings.HTTP_AUTH_PASSWORD
+    combined = '{}:{}'.format(user, password)
+    return base64.b64encode(combined)
+
+
+def basic_auth(func):
+    """Require HTTP basic authentication"""
+    @wraps(func)
+    def wrapped(request, *args, **kwargs):
+        auth_str = request.META.get('HTTP_AUTHORIZATION', '')
+        auth_parts = auth_str.split()
+        if len(auth_parts) != 2 or auth_parts[0].upper() != 'BASIC':
+            return _not_authorized()
+        elif auth_parts[1] != _basic_auth_str():
+            return _not_authorized()
+        else:
+            return func(request, *args, **kwargs)
+    return wrapped
+
+
+def secure_write(func):
+    """Depending on configuration, wrap each request in the appropriate
+    security checks"""
+    func = csrf_exempt(func)
+    enable_auth = (hasattr(settings, 'HTTP_AUTH_USER') and
+                   hasattr(settings, 'HTTP_AUTH_PASSWORD'))
+    if enable_auth:
+        func = basic_auth(func)
+
+    return func


### PR DESCRIPTION
This defaults to off, activated by the presence of two environment variables.

HTTP Basic is fine enough as we only deploy in SSL environments.

Resolves #11 
