### PR TITLE
Bit of cleanup for a test

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,2 @@
+exclude_paths:
+  - docs/*

--- a/regcore_write/tests/views_layer_tests.py
+++ b/regcore_write/tests/views_layer_tests.py
@@ -1,199 +1,128 @@
 import json
-from unittest import TestCase
 
-from django.test.client import Client
+from django.test import TestCase
 from mock import patch
 
-from regcore_write.views.layer import *
+from regcore_write.views import layer
 
 
 class ViewsLayerTest(TestCase):
+    def put(self, data, name='layname', label='lablab', version='verver'):
+        """Shorthand function for PUTing data to a view layer"""
+        url = '/layer/{}/{}/{}'.format(name, label, version)
+        if isinstance(data, dict):
+            data = json.dumps(data)
+        return self.client.put(url, content_type='application/json',
+                               data=data)
 
     def test_add_not_json(self):
-        url = '/layer/layname/lablab/verver'
-
-        response = Client().put(url, content_type='application/json',
-                                data='{Invalid}')
+        """Non-JSON is invalid"""
+        response = self.put('{Invalid}')
         self.assertEqual(400, response.status_code)
 
     def test_add_label_mismatch(self):
-        url = '/layer/layname/lablab/verver'
-
-        response = Client().put(url, content_type='application/json',
-                                data=json.dumps({'nonlab': []}))
+        """Root label must match that found in the url"""
+        response = self.put({'nonlab': []}, label='lablab')
         self.assertEqual(400, response.status_code)
 
-    @patch('regcore_write.views.layer.db')
-    def test_add_success(self, db):
-        url = '/layer/layname/lablab/verver'
+    def put_with_mock_data(self, message, *labels, **kwargs):
+        """Helper function to mock out the value returned from fetching the
+        regulation from the database, then put the provided message, and
+        return the response."""
+        root = []
+        children = root
+        for label in labels:
+            node = {'label': label.split('-'), 'children': []}
+            children.append(node)
+            children = node['children']
 
+        with patch('regcore_write.views.layer.db') as db:
+            db.Regulations.return_value.get.return_value = root[0]
+            self.put(message, **kwargs)
+            self.assertTrue(db.Layers.return_value.bulk_put.called)
+            layers_saved = db.Layers.return_value.bulk_put.call_args[0][0]
+            return list(reversed(layers_saved))     # switch to outside in
+
+    def test_add_success(self):
+        """Can correctly add layer data when node is present in the db"""
         message = {
             'lablab': [1, 2],
             'lablab-b': [2, 3],
             'lablab-b-4': [3, 4],
         }
-        db.Regulations.return_value.get.return_value = {
-            'label': ['lablab'],
-            'children': [{
-                'label': ['lablab', 'b'],
-                'children': [{
-                    'label': ['lablab', 'b', '4'],
-                    'children': []
-                }]
-            }]
-        }
-        response = Client().put(url, content_type='application/json',
-                                data=json.dumps(message))
-        self.assertTrue(db.Layers.return_value.bulk_put.called)
-        args = db.Layers.return_value.bulk_put.call_args[0][0]
-        args = list(reversed(args))   # switch to outside in
+        l1, l2, l3 = self.put_with_mock_data(
+            message, 'lablab', 'lablab-b', 'lablab-b-4')
 
-        self.assertEqual(3, len(args))
         message['label'] = 'lablab'
-        self.assertEqual(message, args[0])
+        self.assertEqual(message, l1)
 
         #   Sub layers have fewer elements
         del message['lablab']
         message['label'] = 'lablab-b'
-        self.assertEqual(message, args[1])
+        self.assertEqual(message, l2)
         del message['lablab-b']
         message['label'] = 'lablab-b-4'
-        self.assertEqual(message, args[2])
+        self.assertEqual(message, l3)
 
-    @patch('regcore_write.views.layer.db')
-    def test_add_skip_level(self, db):
-        url = '/layer/layname/lablab/verver'
-
+    def test_add_skip_level(self):
+        """Can correctly add layer data, even when skipping a node"""
         message = {
             'lablab': [1, 2],
             'lablab-b-4': [3, 4],
         }
-        db.Regulations.return_value.get.return_value = {
-            'label': ['lablab'],
-            'children': [{
-                'label': ['lablab', 'b'],
-                'children': [{
-                    'label': ['lablab', 'b', '4'],
-                    'children': []
-                }]
-            }]
-        }
-        response = Client().put(url, content_type='application/json',
-                                data=json.dumps(message))
-        self.assertTrue(db.Layers.return_value.bulk_put.called)
-        args = db.Layers.return_value.bulk_put.call_args[0][0]
-        args = list(reversed(args))   # switch to outside in
+        l1, l2, l3 = self.put_with_mock_data(
+            message, 'lablab', 'lablab-b', 'lablab-b-4')
 
-        self.assertEqual(3, len(args))
         message['label'] = 'lablab'
-        self.assertEqual(message, args[0])
+        self.assertEqual(message, l1)
         #   Sub layers have fewer elements
         del message['lablab']
         message['label'] = 'lablab-b'
-        self.assertEqual(message, args[1])
+        self.assertEqual(message, l2)
         message['label'] = 'lablab-b-4'
-        self.assertEqual(message, args[2])
+        self.assertEqual(message, l3)
 
-    @patch('regcore_write.views.layer.db')
-    def test_add_interp_children(self, db):
-        url = '/layer/layname/99/verver'
-
+    def test_add_interp_children(self):
+        """Can correctly add layer data to interpretations"""
         message = {'99-5-Interp': [1, 2], '99-5-a-Interp': [3, 4]}
-        db.Regulations.return_value.get.return_value = {
-            'label': ['99'],
-            'children': [{
-                'label': ['99', 'Interp'],
-                'children': [{
-                    'label': ['99', '5', 'Interp'],
-                    'children': [{
-                        'label': ['99', '5', 'a', 'Interp'],
-                        'children': [],
-                    }]
-                }]
-            }]
-        }
-        Client().put(url, content_type='application/json',
-                     data=json.dumps(message))
-        args = db.Layers.return_value.bulk_put.call_args[0][0]
-        self.assertEqual(4, len(args))
-        args = list(reversed(args))   # switch to outside in
-        self.assertTrue('99-5-Interp' in args[0])
-        self.assertTrue('99-5-a-Interp' in args[0])
-        self.assertTrue('99-5-Interp' in args[1])
-        self.assertTrue('99-5-a-Interp' in args[1])
-        self.assertTrue('99-5-Interp' in args[2])
-        self.assertTrue('99-5-a-Interp' in args[2])
-        self.assertFalse('99-5-Interp' in args[3])
-        self.assertTrue('99-5-a-Interp' in args[3])
+        layers_saved = self.put_with_mock_data(
+            message, '99', '99-Interp', '99-5-Interp', '99-5-a-Interp',
+            label='99')
+        self.assertEqual(4, len(layers_saved))
+        for saved in layers_saved:
+            self.assertTrue('99-5-Interp' in saved)
+            self.assertTrue('99-5-a-Interp' in saved)
 
-    @patch('regcore_write.views.layer.db')
-    def test_add_subpart_children(self, db):
-        url = '/layer/layname/99/verver'
-
+    def test_add_subpart_children(self):
+        """Can correctly add layer data to subparts"""
         message = {'99-1': [1, 2], '99-1-a': [3, 4]}
-        db.Regulations.return_value.get.return_value = {
-            'label': ['99'],
-            'children': [{
-                'label': ['99', 'Subpart', 'A'],
-                'children': [{
-                    'label': ['99', '1'],
-                    'children': [{
-                        'label': ['99', '1', 'a'],
-                        'children': []
-                    }]
-                }]
-            }]
-        }
-        Client().put(url, content_type='application/json',
-                     data=json.dumps(message))
-        args = db.Layers.return_value.bulk_put.call_args[0][0]
-        self.assertEqual(4, len(args))
-        args = list(reversed(args))   # switch to outside in
-        self.assertTrue('99-1' in args[0])
-        self.assertTrue('99-1' in args[1])
-        self.assertTrue('99-1' in args[2])
-        self.assertTrue('99-1-a' in args[0])
-        self.assertTrue('99-1-a' in args[1])
-        self.assertTrue('99-1-a' in args[2])
-        self.assertTrue('99-1-a' in args[3])
+        l1, l2, l3, l4 = self.put_with_mock_data(
+            message, '99', '99-Subpart-A', '99-1', '99-1-a', label='99')
+        for saved in (l1, l2, l3):
+            self.assertTrue('99-1' in saved)
 
-    @patch('regcore_write.views.layer.db')
-    def test_add_referenced(self, db):
-        url = '/layer/layname/99/verver'
+        for saved in (l1, l2, l3, l4):
+            self.assertTrue('99-1-a' in saved)
 
+    def test_add_referenced(self):
+        """The 'referenced' key is special; it should get added"""
         message = {'99-1': [1, 2], '99-1-a': [3, 4], 'referenced': [5, 6]}
-        db.Regulations.return_value.get.return_value = {
-            'label': ['99'],
-            'children': [{
-                'label': ['99', 'Subpart', 'A'],
-                'children': [{
-                    'label': ['99', '1'],
-                    'children': [{
-                        'label': ['99', '1', 'a'],
-                        'children': []
-                    }]
-                }]
-            }]
-        }
-        Client().put(url, content_type='application/json',
-                     data=json.dumps(message))
-        args = db.Layers.return_value.bulk_put.call_args[0][0]
-        self.assertEqual(4, len(args))
-        self.assertTrue('referenced' in args[0])
-        self.assertTrue('referenced' in args[1])
-        self.assertTrue('referenced' in args[2])
-        self.assertTrue('referenced' in args[3])
+        layers_saved = self.put_with_mock_data(
+            message, '99', '99-Subpart-A', '99-1', '99-1-a', label='99')
+        self.assertEqual(4, len(layers_saved))
+        self.assertTrue(all('referenced' in saved for saved in layers_saved))
 
     @patch('regcore_write.views.layer.db')
     def test_child_layers_no_results(self, db):
+        """If the db returns no regulation data, nothing should get saved"""
         db.Regulations.return_value.get.return_value = None
-        self.assertEqual([], child_layers('layname', 'lll', 'vvv', {}))
+        self.assertEqual([], layer.child_layers('layname', 'lll', 'vvv', {}))
         self.assertTrue(db.Regulations.return_value.get.called)
-        self.assertEqual('lll',
-                         db.Regulations.return_value.get.call_args[0][0])
-        self.assertEqual('vvv',
-                         db.Regulations.return_value.get.call_args[0][1])
+        lab, ver = db.Regulations.return_value.get.call_args[0]
+        self.assertEqual('lll', lab)
+        self.assertEqual('vvv', ver)
 
     def test_child_label_of(self):
-        self.assertTrue(child_label_of('1005-5-a-1-Interp-1',
+        """Correctly determine relationships between labels"""
+        self.assertTrue(layer.child_label_of('1005-5-a-1-Interp-1',
                         '1005-5-Interp'))

--- a/regcore_write/tests/views_layer_tests.py
+++ b/regcore_write/tests/views_layer_tests.py
@@ -85,13 +85,14 @@ class ViewsLayerTest(TestCase):
     def test_add_interp_children(self):
         """Can correctly add layer data to interpretations"""
         message = {'99-5-Interp': [1, 2], '99-5-a-Interp': [3, 4]}
-        layers_saved = self.put_with_mock_data(
+        l1, l2, l3, l4 = self.put_with_mock_data(
             message, '99', '99-Interp', '99-5-Interp', '99-5-a-Interp',
             label='99')
-        self.assertEqual(4, len(layers_saved))
-        for saved in layers_saved:
+        for saved in (l1, l2, l3):
             self.assertTrue('99-5-Interp' in saved)
             self.assertTrue('99-5-a-Interp' in saved)
+        self.assertFalse('99-5-Interp' in l4)
+        self.assertTrue('99-5-a-Interp' in l4)
 
     def test_add_subpart_children(self):
         """Can correctly add layer data to subparts"""
@@ -100,9 +101,9 @@ class ViewsLayerTest(TestCase):
             message, '99', '99-Subpart-A', '99-1', '99-1-a', label='99')
         for saved in (l1, l2, l3):
             self.assertTrue('99-1' in saved)
-
-        for saved in (l1, l2, l3, l4):
             self.assertTrue('99-1-a' in saved)
+        self.assertFalse('99-1' in l4)
+        self.assertTrue('99-1-a' in l4)
 
     def test_add_referenced(self):
         """The 'referenced' key is special; it should get added"""


### PR DESCRIPTION
Code Climate declared this the worst file in -core, so I've cleaned it up a bit. Notably, I've added a docstring for every test and moved a great deal of duplicated code into a single helper function.

I also added a file to instruct code climate to ignore document files, as those are more or less generated.
