### PR TITLE
Empty dicts shouldn't cause 404s

### DIFF
--- a/regcore_read/tests/views_diff_tests.py
+++ b/regcore_read/tests/views_diff_tests.py
@@ -8,12 +8,18 @@ from regcore_read.views.diff import *
 
 
 class ViewsDiffTest(TestCase):
-
     @patch('regcore_read.views.diff.db')
     def test_get_none(self, db):
         db.Diffs.return_value.get.return_value = None
         response = Client().get('/diff/lablab/oldold/newnew')
         self.assertEqual(404, response.status_code)
+
+    @patch('regcore_read.views.diff.db')
+    def test_get_empty(self, db):
+        db.Diffs.return_value.get.return_value = {}
+        response = Client().get('/diff/lablab/oldold/newnew')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({}, json.loads(response.content))
 
     @patch('regcore_read.views.diff.db')
     def test_get_results(self, db):

--- a/regcore_read/tests/views_notice_tests.py
+++ b/regcore_read/tests/views_notice_tests.py
@@ -8,12 +8,18 @@ from regcore_read.views.notice import *
 
 
 class ViewsNoticeTest(TestCase):
-
     @patch('regcore_read.views.notice.db')
     def test_get_none(self, db):
         db.Notices.return_value.get.return_value = None
         response = Client().get('/notice/docdoc')
         self.assertEqual(404, response.status_code)
+
+    @patch('regcore_read.views.notice.db')
+    def test_get_empty(self, db):
+        db.Notices.return_value.get.return_value = {}
+        response = Client().get('/notice/docdoc')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({}, json.loads(response.content))
 
     @patch('regcore_read.views.notice.db')
     def test_get_results(self, db):

--- a/regcore_read/tests/views_regulation_tests.py
+++ b/regcore_read/tests/views_regulation_tests.py
@@ -8,7 +8,6 @@ from regcore_read.views.regulation import *
 
 
 class ViewsRegulationTest(TestCase):
-
     @patch('regcore_read.views.regulation.db')
     def test_get_good(self, db):
         url = '/regulation/lab/ver'
@@ -20,6 +19,18 @@ class ViewsRegulationTest(TestCase):
         self.assertTrue('ver' in args)
         self.assertEqual(200, response.status_code)
         self.assertEqual({'some': 'thing'}, json.loads(response.content))
+
+    @patch('regcore_read.views.regulation.db')
+    def test_get_empty(self, db):
+        url = '/regulation/lab/ver'
+        db.Regulations.return_value.get.return_value = {}
+        response = Client().get(url)
+        self.assertTrue(db.Regulations.return_value.get.called)
+        args = db.Regulations.return_value.get.call_args[0]
+        self.assertTrue('lab' in args)
+        self.assertTrue('ver' in args)
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({}, json.loads(response.content))
 
     @patch('regcore_read.views.regulation.db')
     def test_get_404(self, db):

--- a/regcore_read/views/diff.py
+++ b/regcore_read/views/diff.py
@@ -5,7 +5,7 @@ from regcore.responses import four_oh_four, success
 def get(request, label_id, old_version, new_version):
     """Find and return the diff with the provided label / versions"""
     diff = db.Diffs().get(label_id, old_version, new_version)
-    if diff:
+    if diff is not None:
         return success(diff)
     else:
         return four_oh_four()

--- a/regcore_read/views/notice.py
+++ b/regcore_read/views/notice.py
@@ -5,7 +5,7 @@ from regcore.responses import four_oh_four, success
 def get(request, docnum):
     """Find and return the notice with this docnum"""
     notice = db.Notices().get(docnum)
-    if notice:
+    if notice is not None:
         return success(notice)
     else:
         return four_oh_four()

--- a/regcore_read/views/regulation.py
+++ b/regcore_read/views/regulation.py
@@ -42,7 +42,7 @@ def listing(request, label_id=None):
 def get(request, label_id, version):
     """Find and return the regulation with this version and label"""
     regulation = db.Regulations().get(label_id, version)
-    if regulation:
+    if regulation is not None:
         return success(regulation)
     else:
         return four_oh_four()


### PR DESCRIPTION
First half to resolving 18f/atf-eregs#113 . While an empty notice/regulation/diff probably isn't what the user intended, it shouldn't be a 404. If we want to add warnings, we should do so in the parser.
