### PR TITLE
Update build and test reporting badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 regulations-core
 ================
 
-[![Build Status](https://travis-ci.org/cfpb/regulations-core.png)](https://travis-ci.org/cfpb/regulations-core)
-[![Coverage Status](https://coveralls.io/repos/cfpb/regulations-core/badge.png)](https://coveralls.io/r/cfpb/regulations-core)
+[![Build Status](https://travis-ci.org/18F/regulations-core.png)](https://travis-ci.org/18F/regulations-core)
+[![Coverage Status](https://coveralls.io/repos/18F/regulations-core/badge.svg?branch=master&service=github)](https://coveralls.io/github/18F/regulations-core?branch=master)
 [![Code Issues](https://www.quantifiedcode.com/api/v1/project/0cdc7eb543724f60b428aa9cae42bd5f/badge.svg)](https://www.quantifiedcode.com/app/project/0cdc7eb543724f60b428aa9cae42bd5f)
 
 An API that provides an interface for storing and retrieving regulations,


### PR DESCRIPTION
Updates Travis and Coveralls badges to point to the 18F repo, not CFPB.
