### PR TITLE
Updating CFPB docs link to shared docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An API that provides an interface for storing and retrieving regulations,
 layers, etc.
 
 This repository is part of a larger project. To read about it, please see 
-[https://cfpb.github.io/eRegulations/](https://cfpb.github.io/eRegulations/).
+[http://eregs.github.io/eRegulations/](http://eregs.github.io/eRegulations/).
 
 ## Features
 


### PR DESCRIPTION
Updating http://cfpb.github.io/eRegulations/ to http://eregs.github.io/eRegulations/ since the shared site has a more comprehensive explanation of the various agencies and repositories involved in this project.
