### PR TITLE
Add support for Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: python
 sudo: false
 python:
     - "2.7"
-    - "3.2"
     - "3.3"
     - "3.4"
     - "3.5"
     - "pypy"
-    - "pypy3"
+    # - "3.2" pyelasticsearch is not compatible
+    # - "pypy3" requires sudo in travis
 install: 
     - pip install -r requirements.txt
     - pip install -r requirements_test.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 sudo: false
 python:
     - "2.7"
+    - "3.2"
+    - "3.3"
+    - "3.4"
+    - "3.5"
 install: 
     - pip install -r requirements.txt
     - pip install -r requirements_test.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
     - "3.3"
     - "3.4"
     - "3.5"
+    - "pypy"
+    - "pypy3"
 install: 
     - pip install -r requirements.txt
     - pip install -r requirements_test.txt

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository is part of a larger project. To read about it, please see
 
 ## Requirements
 
-This application requires Python 2.7
+This application requires Python 2.7 (including PyPy), 3.3, 3.4, 3.5
 
 Requirements are retrieved and/or build automatically via pip (see below).
 

--- a/regcore/db/django_models.py
+++ b/regcore/db/django_models.py
@@ -39,8 +39,8 @@ class DMRegulations(object):
         # This does not handle subparts. Ignoring that for now
         Regulation.objects.filter(version=version,
                                   label_string__startswith=root_label).delete()
-        Regulation.objects.bulk_create(map(
-            lambda r: self._transform(r, version), regs), batch_size=100)
+        Regulation.objects.bulk_create(
+            [self._transform(r, version) for r in regs], batch_size=100)
 
     def listing(self, label=None):
         """List regulation version-label pairs that match this label (or are
@@ -71,8 +71,8 @@ class DMLayers(object):
         # This does not handle subparts. Ignoring that for now
         Layer.objects.filter(version=version, name=layer_name,
                              label__startswith=root_label).delete()
-        Layer.objects.bulk_create(map(
-            lambda l: self._transform(l, version, layer_name), layers),
+        Layer.objects.bulk_create(
+            [self._transform(l, version, layer_name) for l in layers],
             batch_size=100)
 
     def get(self, name, label, version):

--- a/regcore/db/es.py
+++ b/regcore/db/es.py
@@ -39,7 +39,7 @@ class ESRegulations(object):
     def bulk_put(self, regs, version, root_label):
         """Store all reg objects"""
         self.es.bulk_index(settings.ELASTIC_SEARCH_INDEX, 'reg_tree',
-                           map(lambda r: self._transform(r, version), regs))
+                           [self._transform(r, version) for r in regs])
 
     def listing(self, label=None):
         """List regulation version-label pairs that match this label (or are
@@ -77,8 +77,7 @@ class ESLayers(object):
         """Store all layer objects"""
         self.es.bulk_index(
             settings.ELASTIC_SEARCH_INDEX, 'layer',
-            map(lambda l: self._transform(l, version, layer_name),
-                layers))
+            [self._transform(l, version, layer_name) for l in layers])
 
     def get(self, name, label, version):
         """Find the layer that matches these parameters"""

--- a/regcore/tests/db_django_models_tests.py
+++ b/regcore/tests/db_django_models_tests.py
@@ -9,7 +9,7 @@ from regcore.models import Diff, Layer, Notice, Regulation
 
 class ReusableDMRegulations(object):
     def test_get_404(self):
-        self.assertEqual(None, self.dmr.get('lablab', 'verver'))
+        self.assertIsNone(self.dmr.get('lablab', 'verver'))
 
     def test_get_success(self):
         Regulation(version='verver', label_string='a-b', text='ttt',
@@ -108,7 +108,7 @@ class DMRegulationsTest(TestCase, ReusableDMRegulations):
 
 class ReusableDMLayers(object):
     def test_get_404(self):
-        self.assertEqual(None, self.dml.get('namnam', 'lablab', 'verver'))
+        self.assertIsNone(self.dml.get('namnam', 'lablab', 'verver'))
 
     def test_get_success(self):
         Layer(version='verver', name='namnam', label='lablab',
@@ -160,7 +160,7 @@ class DMLayersTest(TestCase, ReusableDMLayers):
 
 class ReusableDMNotices(object):
     def test_get_404(self):
-        self.assertEqual(None, self.dmn.get('docdoc'))
+        self.assertIsNone(self.dmn.get('docdoc'))
 
     def test_get_success(self):
         Notice(document_number='docdoc', fr_url='frfr',
@@ -239,7 +239,7 @@ class DMNoticesTest(TestCase, ReusableDMNotices):
 
 class ReusableDMDiff(object):
     def test_get_404(self):
-        self.assertEqual(None, self.dmd.get('lablab', 'oldold', 'newnew'))
+        self.assertIsNone(self.dmd.get('lablab', 'oldold', 'newnew'))
 
     def test_get_success(self):
         Diff(label='lablab', old_version='oldold', new_version='newnew',

--- a/regcore/tests/db_es_tests.py
+++ b/regcore/tests/db_es_tests.py
@@ -13,7 +13,7 @@ class ESRegulationsTest(TestCase):
         es.return_value.get.side_effect = ElasticHttpNotFoundError
         esr = ESRegulations()
 
-        self.assertEqual(None, esr.get('lablab', 'verver'))
+        self.assertIsNone(esr.get('lablab', 'verver'))
         self.assertEqual('reg_tree', es.return_value.get.call_args[0][1])
         self.assertEqual('verver/lablab', es.return_value.get.call_args[0][2])
 
@@ -72,14 +72,14 @@ class ESRegulationsTest(TestCase):
         ]}}
         esr = ESRegulations()
         results = esr.listing('lll')
-        self.assertFalse('root' in str(es.return_value.search.call_args[0][0]))
-        self.assertTrue('ll' in str(es.return_value.search.call_args[0][0]))
+        self.assertNotIn('root', str(es.return_value.search.call_args[0][0]))
+        self.assertIn('ll', str(es.return_value.search.call_args[0][0]))
         self.assertEqual([('333', 'lll'), ('aaa', 'lll'), ('four', 'lll'),
                           ('ver1', 'lll')], results)
 
         results = esr.listing()
-        self.assertTrue('root' in str(es.return_value.search.call_args[0][0]))
-        self.assertFalse('ll' in str(es.return_value.search.call_args[0][0]))
+        self.assertIn('root', str(es.return_value.search.call_args[0][0]))
+        self.assertNotIn('ll', str(es.return_value.search.call_args[0][0]))
 
 
 class ESLayersTest(TestCase):
@@ -89,7 +89,7 @@ class ESLayersTest(TestCase):
         es.return_value.get.side_effect = ElasticHttpNotFoundError
         esl = ESLayers()
 
-        self.assertEqual(None, esl.get('namnam', 'lablab', 'verver'))
+        self.assertIsNone(esl.get('namnam', 'lablab', 'verver'))
         self.assertEqual('layer', es.return_value.get.call_args[0][1])
         self.assertEqual('verver/namnam/lablab',
                          es.return_value.get.call_args[0][2])
@@ -137,7 +137,7 @@ class ESNoticesTest(TestCase):
         es.return_value.get.side_effect = ElasticHttpNotFoundError
         esn = ESNotices()
 
-        self.assertEqual(None, esn.get('docdoc'))
+        self.assertIsNone(esn.get('docdoc'))
         self.assertEqual('notice', es.return_value.get.call_args[0][1])
         self.assertEqual('docdoc', es.return_value.get.call_args[0][2])
 
@@ -161,7 +161,7 @@ class ESNoticesTest(TestCase):
         self.assertEqual(3, len(args))
         self.assertEqual('notice', args[1])
         self.assertEqual({"some": "structure"}, args[2])
-        self.assertTrue('id' in kwargs)
+        self.assertIn('id', kwargs)
         self.assertEqual('docdoc', kwargs['id'])
 
     @patch('regcore.db.es.ElasticSearch')
@@ -184,7 +184,7 @@ class ESNoticesTest(TestCase):
                           {'document_number': 9}], esn.listing('876'))
         self.assertEqual('notice',
                          es.return_value.search.call_args[1]['doc_type'])
-        self.assertTrue('876' in str(es.return_value.search.call_args[0][0]))
+        self.assertIn('876', str(es.return_value.search.call_args[0][0]))
 
 
 class ESDiffTest(TestCase):
@@ -194,7 +194,7 @@ class ESDiffTest(TestCase):
         es.return_value.get.side_effect = ElasticHttpNotFoundError
         eds = ESDiffs()
 
-        self.assertEqual(None, eds.get('lablab', 'oldold', 'newnew'))
+        self.assertIsNone(eds.get('lablab', 'oldold', 'newnew'))
         self.assertEqual('diff', es.return_value.get.call_args[0][1])
         self.assertEqual('lablab/oldold/newnew',
                          es.return_value.get.call_args[0][2])

--- a/regcore/tests/db_splitter_tests.py
+++ b/regcore/tests/db_splitter_tests.py
@@ -172,7 +172,7 @@ class SplitterNoticesTest(TestCase, dm.ReusableDMNotices):
         self.assertEqual(3, len(args))
         self.assertEqual('notice', args[1])
         self.assertEqual(doc, args[2])
-        self.assertTrue('id' in kwargs)
+        self.assertIn('id', kwargs)
         self.assertEqual('docdoc', kwargs['id'])
 
     @patch('regcore.db.es.ElasticSearch')

--- a/regcore/tests/responses_tests.py
+++ b/regcore/tests/responses_tests.py
@@ -11,7 +11,7 @@ class ResponsesTest(TestCase):
         self.assertEqual(400, response.status_code)
         self.assertEqual('application/json', response['Content-type'])
         response_text = response.content.decode('utf-8')
-        self.assertTrue('my reason' in response_text)
+        self.assertIn('my reason', response_text)
         json.loads(response_text)   # valid json
 
     def test_success_empty(self):

--- a/regcore/tests/responses_tests.py
+++ b/regcore/tests/responses_tests.py
@@ -10,8 +10,9 @@ class ResponsesTest(TestCase):
         response = user_error("my reason")
         self.assertEqual(400, response.status_code)
         self.assertEqual('application/json', response['Content-type'])
-        self.assertTrue('my reason' in response.content)
-        json.loads(response.content)   # valid json
+        response_text = response.content.decode('utf-8')
+        self.assertTrue('my reason' in response_text)
+        json.loads(response_text)   # valid json
 
     def test_success_empty(self):
         response = success()
@@ -23,4 +24,5 @@ class ResponsesTest(TestCase):
         response = success(structure)
         self.assertEqual(200, response.status_code)
         self.assertEqual('application/json', response['Content-type'])
-        self.assertEqual(structure, json.loads(response.content))
+        self.assertEqual(structure,
+                         json.loads(response.content.decode('utf-8')))

--- a/regcore_read/tests/views_diff_tests.py
+++ b/regcore_read/tests/views_diff_tests.py
@@ -17,7 +17,7 @@ class ViewsDiffTest(TestCase):
         db.Diffs.return_value.get.return_value = {}
         response = Client().get('/diff/lablab/oldold/newnew')
         self.assertEqual(200, response.status_code)
-        self.assertEqual({}, json.loads(response.content))
+        self.assertEqual({}, json.loads(response.content.decode('utf-8')))
 
     @patch('regcore_read.views.diff.db')
     def test_get_results(self, db):
@@ -25,4 +25,4 @@ class ViewsDiffTest(TestCase):
         response = Client().get('/diff/lablab/oldold/newnew')
         self.assertEqual(200, response.status_code)
         self.assertEqual({'example': 'response'},
-                         json.loads(response.content))
+                         json.loads(response.content.decode('utf-8')))

--- a/regcore_read/tests/views_es_search_tests.py
+++ b/regcore_read/tests/views_es_search_tests.py
@@ -28,7 +28,7 @@ class ViewsESSearchTest(TestCase):
         self.assertEqual(200, response.status_code)
         self.assertTrue(es.called)
         self.assertTrue(es.return_value.search.called)
-        self.assertTrue('12345678' in str(es.return_value.search.call_args))
+        self.assertIn('12345678', str(es.return_value.search.call_args))
 
     @patch('regcore_read.views.es_search.ElasticSearch')
     def test_search_version_regulation(self, es):
@@ -38,8 +38,8 @@ class ViewsESSearchTest(TestCase):
         self.assertEqual(200, response.status_code)
         self.assertTrue(es.called)
         self.assertTrue(es.return_value.search.called)
-        self.assertTrue('678' in str(es.return_value.search.call_args))
-        self.assertTrue('123' in str(es.return_value.search.call_args))
+        self.assertIn('678', str(es.return_value.search.call_args))
+        self.assertIn('123', str(es.return_value.search.call_args))
 
     @patch('regcore_read.views.es_search.ElasticSearch')
     def test_search_paging(self, es):
@@ -80,7 +80,7 @@ class ViewsESSearchTest(TestCase):
             {'regulation': 'r', 'version': 'v', 'label_string': '7',
              'title': 't7'}])
 
-        self.assertFalse('title' in results[0])
+        self.assertNotIn('title', results[0])
         self.assertEqual('d1', results[1]['title'])
         self.assertEqual('k2', results[2]['title'])
         self.assertEqual('k3', results[3]['title'])

--- a/regcore_read/tests/views_haystack_search_tests.py
+++ b/regcore_read/tests/views_haystack_search_tests.py
@@ -86,7 +86,7 @@ class ViewsHaystackSearchTest(TestCase):
             Result('r', 'v', '7', '', ['t7']),
         ])
 
-        self.assertFalse('title' in results[0])
+        self.assertNotIn('title', results[0])
         self.assertEqual('d1', results[1]['title'])
         self.assertEqual('k2', results[2]['title'])
         self.assertEqual('k3', results[3]['title'])

--- a/regcore_read/tests/views_layer_tests.py
+++ b/regcore_read/tests/views_layer_tests.py
@@ -21,11 +21,11 @@ class ViewsLayerTest(TestCase):
         response = Client().get('/layer/nnn/lll/vvv')
         self.assertEqual(200, response.status_code)
         self.assertEqual({'example': 'response'},
-                         json.loads(response.content))
+                         json.loads(response.content.decode('utf-8')))
 
     @patch('regcore_read.views.layer.db')
     def test_get_results_empty_layer(self, db):
         db.Layers.return_value.get.return_value = {}
         response = Client().get('/layer/nnn/lll/vvv')
         self.assertEqual(200, response.status_code)
-        self.assertEqual({}, json.loads(response.content))
+        self.assertEqual({}, json.loads(response.content.decode('utf-8')))

--- a/regcore_read/tests/views_notice_tests.py
+++ b/regcore_read/tests/views_notice_tests.py
@@ -17,7 +17,7 @@ class ViewsNoticeTest(TestCase):
         db.Notices.return_value.get.return_value = {}
         response = Client().get('/notice/docdoc')
         self.assertEqual(200, response.status_code)
-        self.assertEqual({}, json.loads(response.content))
+        self.assertEqual({}, json.loads(response.content.decode('utf-8')))
 
     @patch('regcore_read.views.notice.db')
     def test_get_results(self, db):
@@ -25,7 +25,7 @@ class ViewsNoticeTest(TestCase):
         response = Client().get('/notice/docdoc')
         self.assertEqual(200, response.status_code)
         self.assertEqual({'example': 'response'},
-                         json.loads(response.content))
+                         json.loads(response.content.decode('utf-8')))
 
     @patch('regcore_read.views.notice.db')
     def test_listing(self, db):
@@ -33,4 +33,4 @@ class ViewsNoticeTest(TestCase):
         response = Client().get('/notice')
         self.assertEqual(200, response.status_code)
         self.assertEqual({'results': [1, 2, 3]},
-                         json.loads(response.content))
+                         json.loads(response.content.decode('utf-8')))

--- a/regcore_read/tests/views_regulation_tests.py
+++ b/regcore_read/tests/views_regulation_tests.py
@@ -16,7 +16,8 @@ class ViewsRegulationTest(TestCase):
         self.assertTrue('lab' in args)
         self.assertTrue('ver' in args)
         self.assertEqual(200, response.status_code)
-        self.assertEqual({'some': 'thing'}, json.loads(response.content))
+        self.assertEqual({'some': 'thing'},
+                         json.loads(response.content.decode('utf-8')))
 
     @patch('regcore_read.views.regulation.db')
     def test_get_empty(self, db):
@@ -28,7 +29,7 @@ class ViewsRegulationTest(TestCase):
         self.assertTrue('lab' in args)
         self.assertTrue('ver' in args)
         self.assertEqual(200, response.status_code)
-        self.assertEqual({}, json.loads(response.content))
+        self.assertEqual({}, json.loads(response.content.decode('utf-8')))
 
     @patch('regcore_read.views.regulation.db')
     def test_get_404(self, db):
@@ -57,7 +58,7 @@ class ViewsRegulationTest(TestCase):
         response = Client().get(url)
         self.assertEqual(200, response.status_code)
         found = [False, False, False]
-        for ver in json.loads(response.content)['versions']:
+        for ver in json.loads(response.content.decode('utf-8'))['versions']:
             if ver['version'] == '10' and 'by_date' not in ver:
                 found[0] = True
             if ver['version'] == '15' and ver['by_date'] == '2010-10-10':
@@ -82,7 +83,7 @@ class ViewsRegulationTest(TestCase):
         response = Client().get(url)
         self.assertEqual(200, response.status_code)
         found = [False, False, False]
-        for ver in json.loads(response.content)['versions']:
+        for ver in json.loads(response.content.decode('utf-8'))['versions']:
             if (ver['version'] == '10' and 'by_date' not in ver and
                     ver['regulation'] == '1111'):
                 found[0] = True

--- a/regcore_read/tests/views_regulation_tests.py
+++ b/regcore_read/tests/views_regulation_tests.py
@@ -13,8 +13,8 @@ class ViewsRegulationTest(TestCase):
         response = Client().get(url)
         self.assertTrue(db.Regulations.return_value.get.called)
         args = db.Regulations.return_value.get.call_args[0]
-        self.assertTrue('lab' in args)
-        self.assertTrue('ver' in args)
+        self.assertIn('lab', args)
+        self.assertIn('ver', args)
         self.assertEqual(200, response.status_code)
         self.assertEqual({'some': 'thing'},
                          json.loads(response.content.decode('utf-8')))
@@ -26,8 +26,8 @@ class ViewsRegulationTest(TestCase):
         response = Client().get(url)
         self.assertTrue(db.Regulations.return_value.get.called)
         args = db.Regulations.return_value.get.call_args[0]
-        self.assertTrue('lab' in args)
-        self.assertTrue('ver' in args)
+        self.assertIn('lab', args)
+        self.assertIn('ver', args)
         self.assertEqual(200, response.status_code)
         self.assertEqual({}, json.loads(response.content.decode('utf-8')))
 
@@ -38,8 +38,8 @@ class ViewsRegulationTest(TestCase):
         response = Client().get(url)
         self.assertTrue(db.Regulations.return_value.get.called)
         args = db.Regulations.return_value.get.call_args[0]
-        self.assertTrue('lab' in args)
-        self.assertTrue('ver' in args)
+        self.assertIn('lab', args)
+        self.assertIn('ver', args)
         self.assertEqual(404, response.status_code)
 
     @patch('regcore_read.views.regulation.db')

--- a/regcore_write/tests/views_layer_tests.py
+++ b/regcore_write/tests/views_layer_tests.py
@@ -89,10 +89,10 @@ class ViewsLayerTest(TestCase):
             message, '99', '99-Interp', '99-5-Interp', '99-5-a-Interp',
             label='99')
         for saved in (l1, l2, l3):
-            self.assertTrue('99-5-Interp' in saved)
-            self.assertTrue('99-5-a-Interp' in saved)
-        self.assertFalse('99-5-Interp' in l4)
-        self.assertTrue('99-5-a-Interp' in l4)
+            self.assertIn('99-5-Interp', saved)
+            self.assertIn('99-5-a-Interp', saved)
+        self.assertNotIn('99-5-Interp', l4)
+        self.assertIn('99-5-a-Interp', l4)
 
     def test_add_subpart_children(self):
         """Can correctly add layer data to subparts"""
@@ -100,10 +100,10 @@ class ViewsLayerTest(TestCase):
         l1, l2, l3, l4 = self.put_with_mock_data(
             message, '99', '99-Subpart-A', '99-1', '99-1-a', label='99')
         for saved in (l1, l2, l3):
-            self.assertTrue('99-1' in saved)
-            self.assertTrue('99-1-a' in saved)
-        self.assertFalse('99-1' in l4)
-        self.assertTrue('99-1-a' in l4)
+            self.assertIn('99-1', saved)
+            self.assertIn('99-1-a', saved)
+        self.assertNotIn('99-1', l4)
+        self.assertIn('99-1-a', l4)
 
     def test_add_referenced(self):
         """The 'referenced' key is special; it should get added"""

--- a/regcore_write/tests/views_security_tests.py
+++ b/regcore_write/tests/views_security_tests.py
@@ -13,7 +13,8 @@ def _wrapped_fn(request):
 
 
 def _encode(username, password):
-    encoded = base64.b64encode('{}:{}'.format(username, password))
+    as_unicode = '{}:{}'.format(username, password).encode()
+    encoded = base64.b64encode(as_unicode).decode('utf-8')
     return 'Basic ' + encoded
 
 

--- a/regcore_write/views/diff.py
+++ b/regcore_write/views/diff.py
@@ -9,8 +9,8 @@ from regcore_write.views.security import secure_write
 def add(request, label_id, old_version, new_version):
     """Add the diff to the db, indexed by the label and versions"""
     try:
-        diff = json.loads(request.body)
-    except ValueError:
+        diff = json.loads(request.body.decode('utf-8'))
+    except (ValueError, UnicodeError):
         return user_error('invalid format')
 
     #   @todo: write a schema that verifies the diff's structure

--- a/regcore_write/views/layer.py
+++ b/regcore_write/views/layer.py
@@ -25,8 +25,8 @@ def child_label_of(lhs, rhs):
 def add(request, name, label_id, version):
     """Add the layer node and all of its children to the db"""
     try:
-        layer = json.loads(request.body)
-    except ValueError:
+        layer = json.loads(request.body.decode('utf-8'))
+    except (ValueError, UnicodeError):
         return user_error('invalid format')
 
     if not isinstance(layer, dict):

--- a/regcore_write/views/notice.py
+++ b/regcore_write/views/notice.py
@@ -9,8 +9,8 @@ from regcore_write.views.security import secure_write
 def add(request, docnum):
     """Add the notice to the db"""
     try:
-        notice = json.loads(request.body)
-    except ValueError:
+        notice = json.loads(request.body.decode('utf-8'))
+    except (ValueError, UnicodeError):
         return user_error('invalid format')
 
     #   @todo: write a schema that verifies the notice's structure

--- a/regcore_write/views/regulation.py
+++ b/regcore_write/views/regulation.py
@@ -36,9 +36,9 @@ REGULATION_SCHEMA = {
 def add(request, label_id, version):
     """Add this regulation node and all of its children to the db"""
     try:
-        node = json.loads(request.body)
+        node = json.loads(request.body.decode('utf-8'))
         jsonschema.validate(node, REGULATION_SCHEMA)
-    except ValueError:
+    except (ValueError, UnicodeError):
         return user_error('invalid format')
     except jsonschema.ValidationError:
         return user_error("JSON is invalid")

--- a/regcore_write/views/security.py
+++ b/regcore_write/views/security.py
@@ -19,7 +19,7 @@ def _is_correct_auth(guess):
     safely compare `guess` against it"""
     user, password = settings.HTTP_AUTH_USER, settings.HTTP_AUTH_PASSWORD
     combined = '{}:{}'.format(user, password)
-    left = base64.b64encode(combined)
+    left = base64.b64encode(combined.encode()).decode('utf-8')
     # Django's built in constant_time_compare short circuits if the length of
     # the strings is not equal. We avoid that by padding both strings out to
     # 1000 characters before running the constant time comparison. Note, that

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'django>=1.8,<1.9',
-        'jsonschema'
+        'jsonschema',
+        'six'
     ]
 )


### PR DESCRIPTION
Minor tweaks around unicode and list comprehensions. Removes a chunk of workaround code which was needed in Django 1.6
