### PR TITLE
Storage for preambles

### DIFF
--- a/regcore/db/django_models.py
+++ b/regcore/db/django_models.py
@@ -3,7 +3,7 @@ etc.), implemented using Django models"""
 from django.core.exceptions import ObjectDoesNotExist
 
 from regcore.db import interface
-from regcore.models import Diff, Layer, Notice, Regulation
+from regcore.models import Diff, Layer, Notice, Preamble, Regulation
 
 
 class DMRegulations(interface.Regulations):
@@ -141,5 +141,21 @@ class DMDiffs(interface.Diffs):
             diff = Diff.objects.get(label=label, old_version=old_version,
                                     new_version=new_version)
             return diff.diff
+        except ObjectDoesNotExist:
+            return None
+
+
+class DMPreambles(interface.Preambles):
+    """Implementation of Django-models as preamble backend"""
+    def put(self, doc_number, preamble):
+        """Store a single preamble"""
+        Preamble.objects.filter(document_number=doc_number).delete()
+        Preamble.objects.create(document_number=doc_number, data=preamble)
+
+    def get(self, doc_number):
+        """Fetch a single preamble"""
+        try:
+            preamble = Preamble.objects.get(document_number=doc_number)
+            return preamble.data
         except ObjectDoesNotExist:
             return None

--- a/regcore/db/es.py
+++ b/regcore/db/es.py
@@ -143,3 +143,15 @@ class ESDiffs(ESBase, interface.Diffs):
                                self.to_id(label, old_version, new_version))
         if diff is not None:
             return diff['diff']
+
+
+class ESPreambles(ESBase, interface.Preambles):
+    """Implementation of Elastic Search as preamble backend"""
+    def put(self, doc_number, preamble):
+        """Store a single preamble"""
+        self.es.index(settings.ELASTIC_SEARCH_INDEX, 'preamble', preamble,
+                      id=doc_number)
+
+    def get(self, doc_number):
+        """Find the associated preamble"""
+        return self.safe_fetch('preamble', doc_number)

--- a/regcore/db/interface.py
+++ b/regcore/db/interface.py
@@ -64,3 +64,15 @@ class Diffs(object):
     def get(self, label, old_version, new_version):
         """Return matching diff or None"""
         raise NotImplementedError
+
+
+@six.add_metaclass(abc.ABCMeta)
+class Preambles(object):
+    def put(self, doc_number, preamble):
+        """:param str doc_number: unique identifier
+           :param dict preamble: preamble data"""
+        raise NotImplementedError
+
+    def get(self, doc_number):
+        """Return matching preamble or None"""
+        raise NotImplementedError

--- a/regcore/db/storage.py
+++ b/regcore/db/storage.py
@@ -9,7 +9,7 @@ def select_for(data_type):
     class_str = settings.BACKENDS.get(
         data_type,
         'regcore.db.django_models.DM' + data_type.capitalize())
-    return import_string(class_str)
+    return import_string(class_str)()
 
 for_regulations = select_for('regulations')
 for_layers = select_for('layers')

--- a/regcore/db/storage.py
+++ b/regcore/db/storage.py
@@ -5,8 +5,12 @@ from django.conf import settings
 
 def select_for(data_type):
     """The storage class for each datatype is defined in a settings file. This
-    will look up the appropriate storage backend and instantiate it"""
-    module, class_name = settings.BACKENDS[data_type].rsplit('.', 1)
+    will look up the appropriate storage backend and instantiate it. If none
+    is found, this will default to the Django ORM versions"""
+    class_str = settings.BACKENDS.get(
+        data_type,
+        'regcore.db.django_models.DM' + data_type.capitalize())
+    module, class_name = class_str.rsplit('.', 1)
     module = import_module(module)
     return getattr(module, class_name)()
 
@@ -14,3 +18,4 @@ for_regulations = select_for('regulations')
 for_layers = select_for('layers')
 for_notices = select_for('notices')
 for_diffs = select_for('diffs')
+for_preambles = select_for('preambles')

--- a/regcore/migrations/0002_preamble.py
+++ b/regcore/migrations/0002_preamble.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import regcore.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('regcore', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Preamble',
+            fields=[
+                ('document_number', models.SlugField(max_length=20, serialize=False, primary_key=True)),
+                ('data', regcore.fields.CompressedJSONField()),
+            ],
+        ),
+    ]

--- a/regcore/migrations/0005_merge.py
+++ b/regcore/migrations/0005_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('regcore', '0002_preamble'),
+        ('regcore', '0004_mptt_delete_fields'),
+    ]
+
+    operations = [
+    ]

--- a/regcore/models.py
+++ b/regcore/models.py
@@ -55,3 +55,9 @@ class Diff(models.Model):
     class Meta:
         index_together = (('label', 'old_version', 'new_version'),)
         unique_together = (('label', 'old_version', 'new_version'),)
+
+
+class Preamble(models.Model):
+    """Represents the explanatory text associated with a notice"""
+    document_number = models.SlugField(max_length=20, primary_key=True)
+    data = CompressedJSONField()

--- a/regcore/settings/base.py
+++ b/regcore/settings/base.py
@@ -29,12 +29,9 @@ ROOT_URLCONF = 'regcore.urls'
 
 DEBUG = True
 
-BACKENDS = {
-    'regulations': 'regcore.db.django_models.DMRegulations',
-    'layers': 'regcore.db.django_models.DMLayers',
-    'notices': 'regcore.db.django_models.DMNotices',
-    'diffs': 'regcore.db.django_models.DMDiffs'
-}
+# Configurable storage backends, keyed by data_type (e.g. regulations, diffs)
+# If a key is not set, defaults to regcore.db.django_models versions
+BACKENDS = {}
 
 NOSE_ARGS = [
     '--with-coverage',

--- a/regcore/tests/db_django_models_tests.py
+++ b/regcore/tests/db_django_models_tests.py
@@ -4,8 +4,8 @@ from django.test import TestCase
 import six
 
 from regcore.db.django_models import (
-    DMDiffs, DMLayers, DMNotices, DMRegulations)
-from regcore.models import Diff, Layer, Notice, Regulation
+    DMDiffs, DMLayers, DMNotices, DMPreambles, DMRegulations)
+from regcore.models import Diff, Layer, Notice, Preamble, Regulation
 
 
 class DMRegulationsTest(TestCase):
@@ -209,4 +209,28 @@ class DMDiffTest(TestCase):
         self.dmd.put('lablab', 'oldold', 'newnew', {"other": "structure"})
         expected['diff'] = {'other': 'structure'}
         six.assertCountEqual(self, Diff.objects.all().values(*fields),
+                             [expected])
+
+
+class DMPreambleTest(TestCase):
+    def test_get(self):
+        """Can fetch preamble docs"""
+        self.assertIsNone(DMPreambles().get('docdoc'))
+
+        Preamble(document_number='docdocdoc', data={'some': 'data'}).save()
+        self.assertEqual({"some": 'data'}, DMPreambles().get('docdocdoc'))
+
+    def test_put(self):
+        """We can insert and replace a pramble"""
+        DMPreambles().put('docdoc', {'some': 'struct', 'here': True})
+
+        expected = {'document_number': 'docdoc',
+                    'data': {'some': 'struct', 'here': True}}
+        fields = expected.keys()
+        six.assertCountEqual(self, Preamble.objects.all().values(*fields),
+                             [expected])
+
+        DMPreambles().put('docdoc', {'other': 1})
+        expected['data'] = {'other': 1}
+        six.assertCountEqual(self, Preamble.objects.all().values(*fields),
                              [expected])

--- a/regcore/tests/db_es_tests.py
+++ b/regcore/tests/db_es_tests.py
@@ -4,7 +4,8 @@ from unittest import TestCase
 from mock import patch
 from pyelasticsearch.exceptions import ElasticHttpNotFoundError
 
-from regcore.db.es import ESDiffs, ESLayers, ESNotices, ESRegulations
+from regcore.db.es import (
+    ESDiffs, ESLayers, ESNotices, ESPreambles, ESRegulations)
 
 
 class ESBase(object):
@@ -184,3 +185,18 @@ class ESDiffTest(TestCase, ESBase):
                           'old_version': 'oldold',
                           'new_version': 'newnew',
                           'diff': {'some': 'structure'}})
+
+
+class ESPreamblesTest(TestCase, ESBase):
+    def test_get_404(self):
+        with self.expect_get('preamble', 'docdoc'):
+            self.assertIsNone(ESPreambles().get('docdoc'))
+
+    def test_get_success(self):
+        with self.expect_get('preamble', 'docdoc', {'arbitrary': True}):
+            self.assertEqual(ESPreambles().get('docdoc'), {'arbitrary': True})
+
+    def test_put(self):
+        with self.expect_put('preamble', 'docdoc'):
+            ESPreambles().put('docdoc', {"some": "structure"})
+        self.assertEqual(self.call_args[0][2], {"some": "structure"})

--- a/regcore/urls.py
+++ b/regcore/urls.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.conf.urls import patterns
 
 from regcore_read.views import (
-    diff as rdiff, layer as rlayer, notice as rnotice,
+    diff as rdiff, layer as rlayer, notice as rnotice, preamble as rpreamble,
     regulation as rregulation)
 from regcore_read.views.haystack_search import search
 from regcore_write.views import (
@@ -26,6 +26,7 @@ if 'regcore_read' in settings.INSTALLED_APPS:
     mapping['layer']['GET'] = rlayer.get
     mapping['notice']['GET'] = rnotice.get
     mapping['notices']['GET'] = rnotice.listing
+    mapping['preamble']['GET'] = rpreamble.get
     mapping['regulation']['GET'] = rregulation.get
     mapping['reg-versions']['GET'] = rregulation.listing
     mapping['search']['GET'] = search
@@ -37,8 +38,8 @@ if 'regcore_write' in settings.INSTALLED_APPS:
         mapping['diff'][verb] = wdiff.add
         mapping['layer'][verb] = wlayer.add
         mapping['notice'][verb] = wnotice.add
-        mapping['regulation'][verb] = wregulation.add
         mapping['preamble'][verb] = wpreamble.add
+        mapping['regulation'][verb] = wregulation.add
 
 
 # Re-usable URL patterns.

--- a/regcore/urls.py
+++ b/regcore/urls.py
@@ -8,11 +8,13 @@ from collections import defaultdict
 from django.conf import settings
 from django.conf.urls import patterns
 
-from regcore_read.views import diff as rdiff, layer as rlayer
-from regcore_read.views import notice as rnotice, regulation as rregulation
+from regcore_read.views import (
+    diff as rdiff, layer as rlayer, notice as rnotice,
+    regulation as rregulation)
 from regcore_read.views.haystack_search import search
-from regcore_write.views import diff as wdiff, layer as wlayer
-from regcore_write.views import notice as wnotice, regulation as wregulation
+from regcore_write.views import (
+    diff as wdiff, layer as wlayer, notice as wnotice, preamble as wpreamble,
+    regulation as wregulation)
 from regcore.urls_utils import by_verb_url
 
 
@@ -36,6 +38,7 @@ if 'regcore_write' in settings.INSTALLED_APPS:
         mapping['layer'][verb] = wlayer.add
         mapping['notice'][verb] = wnotice.add
         mapping['regulation'][verb] = wregulation.add
+        mapping['preamble'][verb] = wpreamble.add
 
 
 # Re-usable URL patterns.
@@ -59,5 +62,7 @@ urlpatterns = patterns(
     by_verb_url(r'^regulation$', 'all-reg-versions', mapping['reg-versions']),
     by_verb_url(r'^regulation/%s$' % seg('label_id'),
                 'reg-versions', mapping['reg-versions']),
+    by_verb_url(r'^preamble/%s$' % seg('docnum'), 'preamble',
+                mapping['preamble']),
     by_verb_url(r'^search$', 'search', mapping['search'])
 )

--- a/regcore_read/tests/views_preamble_tests.py
+++ b/regcore_read/tests/views_preamble_tests.py
@@ -1,0 +1,24 @@
+import json
+
+from django.test import TestCase
+from mock import patch
+
+
+class ViewsPreambleTests(TestCase):
+    @patch('regcore_read.views.preamble.storage')
+    def test_get(self, storage):
+        """We should only give a 404 when we have *no* result. Otherwise,
+        return the retrieved (possible empty) doc"""
+        storage.for_preambles.get.return_value = None
+        self.assertEqual(404, self.client.get('/preamble/docdoc').status_code)
+
+        storage.for_preambles.get.return_value = {}
+        response = self.client.get('/preamble/docdoc')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual({}, json.loads(response.content.decode('utf-8')))
+
+        storage.for_preambles.get.return_value = {'slightly': 'complex'}
+        response = self.client.get('/preamble/docdoc')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(json.loads(response.content.decode('utf-8')),
+                         {'slightly': 'complex'})

--- a/regcore_read/views/preamble.py
+++ b/regcore_read/views/preamble.py
@@ -1,0 +1,11 @@
+from regcore.db import storage
+from regcore.responses import four_oh_four, success
+
+
+def get(request, docnum):
+    """Find and return the preamble with this docnum"""
+    preamble = storage.for_preambles.get(docnum)
+    if preamble is not None:
+        return success(preamble)
+    else:
+        return four_oh_four()

--- a/regcore_write/tests/views_preamble_tests.py
+++ b/regcore_write/tests/views_preamble_tests.py
@@ -1,0 +1,20 @@
+from django.test import TestCase
+from mock import patch
+
+
+class ViewsPreambleTests(TestCase):
+    def test_invalid_json(self):
+        """Only accepts valid JSON"""
+        response = self.client.put(
+            '/preamble/id_here', content_type='application/json',
+            data='{Invalid}')
+        self.assertEqual(400, response.status_code)
+
+    @patch('regcore_write.views.preamble.storage')
+    def test_stores(self, storage):
+        """Stores any JSON it is given"""
+        self.client.put('/preamble/id_here', content_type='application/json',
+                        data='{"some": "data"}')
+        self.assertTrue(storage.for_preambles.put.called)
+        self.assertEqual(storage.for_preambles.put.call_args[0],
+                         ('id_here', {'some': 'data'}))

--- a/regcore_write/views/diff.py
+++ b/regcore_write/views/diff.py
@@ -1,18 +1,13 @@
-import json
-
 from regcore.db import storage
-from regcore.responses import success, user_error
-from regcore_write.views.security import secure_write
+from regcore.responses import success
+from regcore_write.views.security import json_body, secure_write
 
 
 @secure_write
+@json_body
 def add(request, label_id, old_version, new_version):
     """Add the diff to the db, indexed by the label and versions"""
-    try:
-        diff = json.loads(request.body.decode('utf-8'))
-    except (ValueError, UnicodeError):
-        return user_error('invalid format')
-
     #   @todo: write a schema that verifies the diff's structure
-    storage.for_diffs.put(label_id, old_version, new_version, diff)
+    storage.for_diffs.put(
+        label_id, old_version, new_version, request.json_body)
     return success()

--- a/regcore_write/views/layer.py
+++ b/regcore_write/views/layer.py
@@ -1,8 +1,6 @@
-import json
-
 from regcore.db import storage
 from regcore.responses import success, user_error
-from regcore_write.views.security import secure_write
+from regcore_write.views.security import json_body, secure_write
 
 
 def child_label_of(lhs, rhs):
@@ -22,12 +20,10 @@ def child_label_of(lhs, rhs):
 
 
 @secure_write
+@json_body
 def add(request, name, label_id, version):
     """Add the layer node and all of its children to the db"""
-    try:
-        layer = json.loads(request.body.decode('utf-8'))
-    except (ValueError, UnicodeError):
-        return user_error('invalid format')
+    layer = request.json_body
 
     if not isinstance(layer, dict):
         return user_error('invalid format')

--- a/regcore_write/views/notice.py
+++ b/regcore_write/views/notice.py
@@ -1,17 +1,13 @@
-import json
-
 from regcore.db import storage
-from regcore.responses import success, user_error
-from regcore_write.views.security import secure_write
+from regcore.responses import success
+from regcore_write.views.security import json_body, secure_write
 
 
 @secure_write
+@json_body
 def add(request, docnum):
     """Add the notice to the db"""
-    try:
-        notice = json.loads(request.body.decode('utf-8'))
-    except (ValueError, UnicodeError):
-        return user_error('invalid format')
+    notice = request.json_body
 
     #   @todo: write a schema that verifies the notice's structure
     cfr_parts = notice.get('cfr_parts', [])

--- a/regcore_write/views/preamble.py
+++ b/regcore_write/views/preamble.py
@@ -1,16 +1,11 @@
-import json
-
 from regcore.db import storage
-from regcore.responses import success, user_error
-from regcore_write.views.security import secure_write
+from regcore.responses import success
+from regcore_write.views.security import json_body, secure_write
 
 
 @secure_write
+@json_body
 def add(request, docnum):
     """Add the preamble to the db"""
-    try:
-        preamble = json.loads(request.body.decode('utf-8'))
-    except (ValueError, UnicodeError):
-        return user_error('invalid format')
-    storage.for_preambles.put(docnum, preamble)
+    storage.for_preambles.put(docnum, request.json_body)
     return success()

--- a/regcore_write/views/preamble.py
+++ b/regcore_write/views/preamble.py
@@ -1,0 +1,16 @@
+import json
+
+from regcore.db import storage
+from regcore.responses import success, user_error
+from regcore_write.views.security import secure_write
+
+
+@secure_write
+def add(request, docnum):
+    """Add the preamble to the db"""
+    try:
+        preamble = json.loads(request.body.decode('utf-8'))
+    except (ValueError, UnicodeError):
+        return user_error('invalid format')
+    storage.for_preambles.put(docnum, preamble)
+    return success()

--- a/regcore_write/views/regulation.py
+++ b/regcore_write/views/regulation.py
@@ -1,11 +1,10 @@
-import json
 import logging
 
 import jsonschema
 
 from regcore.db import storage
 from regcore.responses import success, user_error
-from regcore_write.views.security import secure_write
+from regcore_write.views.security import json_body, secure_write
 
 
 #   This JSON schema is used to validate the regulation data provided
@@ -33,13 +32,12 @@ REGULATION_SCHEMA = {
 
 
 @secure_write
+@json_body
 def add(request, label_id, version):
     """Add this regulation node and all of its children to the db"""
     try:
-        node = json.loads(request.body.decode('utf-8'))
+        node = request.json_body
         jsonschema.validate(node, REGULATION_SCHEMA)
-    except (ValueError, UnicodeError):
-        return user_error('invalid format')
     except jsonschema.ValidationError:
         return user_error("JSON is invalid")
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ setup(
     packages=find_packages(),
     install_requires=[
         'django>=1.8,<1.9',
+        'django-mptt',
         'jsonschema',
-        'six'
+        'six',
     ]
 )


### PR DESCRIPTION
This adds very, very naive storage for notice preambles. Really, it's just carving out a namespace and allowing _any_ json to be written/read. We can tighten down the schema when we know more.

Builds on #36. See [diff](https://github.com/cmc333333/regulations-core/compare/more-refactors...cmc333333:12-preambles-rebase)

For eregs/notice-and-comment#12
