### PR TITLE
Add django-mptt requirement to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ setup(
     packages=find_packages(),
     install_requires=[
         'django>=1.8,<1.9',
+        'django-mptt',
         'jsonschema',
-        'six'
+        'six',
     ]
 )


### PR DESCRIPTION
Lest projects which use this as a library explode
