### PR TITLE
Use single quotes in raw query.

### DIFF
--- a/regcore/migrations/0007_auto_20160314_1135.py
+++ b/regcore/migrations/0007_auto_20160314_1135.py
@@ -8,7 +8,7 @@ def gen_layer_reference(apps, schema_editor):
     """We'll combine two previously distinct fields to generalize the layers
     interface"""
     schema_editor.execute(
-        'UPDATE regcore_layer SET reference=version||":"||label')
+        "UPDATE regcore_layer SET reference=version||':'||label")
 
 
 def split_layer_reference(apps, schema_editor):


### PR DESCRIPTION
Fixes migration under postgres.
