### PR TITLE
Use namespaces when storing layers

### DIFF
--- a/regcore/db/django_models.py
+++ b/regcore/db/django_models.py
@@ -117,8 +117,7 @@ class DMLayers(interface.Layers):
     def _transform(self, layer, layer_name, doc_type):
         """Create a Django object"""
         layer = dict(layer)  # copy
-        doc_id = layer['doc_id']
-        del layer['doc_id']
+        doc_id = layer.pop('doc_id')
         return Layer(name=layer_name, layer=layer, doc_type=doc_type,
                      doc_id=doc_id)
 

--- a/regcore/db/django_models.py
+++ b/regcore/db/django_models.py
@@ -114,26 +114,29 @@ class DMRegulations(interface.Regulations):
 
 class DMLayers(interface.Layers):
     """Implementation of Django-models as layers backend"""
-    def _transform(self, layer, layer_name):
+    def _transform(self, layer, layer_name, doc_type):
         """Create a Django object"""
         layer = dict(layer)  # copy
-        reference = layer['reference']
-        del layer['reference']
-        return Layer(name=layer_name, layer=layer, reference=reference)
+        doc_id = layer['doc_id']
+        del layer['doc_id']
+        return Layer(name=layer_name, layer=layer, doc_type=doc_type,
+                     doc_id=doc_id)
 
-    def bulk_put(self, layers, layer_name, prefix):
+    def bulk_put(self, layers, layer_name, doc_type, root_doc_id):
         """Store all layer objects"""
-        # This does not handle subparts. Ignoring that for now
-        Layer.objects.filter(name=layer_name,
-                             reference__startswith=prefix).delete()
+        # This does not handle subparts; Ignoring that for now
+        # @todo - use regex to avoid deleting 222-11 when replacing 22
+        Layer.objects.filter(name=layer_name, doc_type=doc_type,
+                             doc_id__startswith=root_doc_id).delete()
         Layer.objects.bulk_create(
-            [self._transform(l, layer_name) for l in layers],
+            [self._transform(l, layer_name, doc_type) for l in layers],
             batch_size=settings.BATCH_SIZE)
 
-    def get(self, name, reference):
+    def get(self, name, doc_type, doc_id):
         """Find the layer that matches these parameters"""
         try:
-            layer = Layer.objects.get(name=name, reference=reference)
+            layer = Layer.objects.get(name=name, doc_type=doc_type,
+                                      doc_id=doc_id)
             return layer.layer
         except ObjectDoesNotExist:
             return None

--- a/regcore/db/es.py
+++ b/regcore/db/es.py
@@ -71,7 +71,7 @@ class ESLayers(ESBase, interface.Layers):
         layer = dict(layer)     # copy
         doc_id = self.sanitize_doc_id(layer['doc_id'])
         del layer['doc_id']
-        return {'id': ':'.join(layer_name, doc_type, doc_id), 'layer': layer}
+        return {'id': ':'.join([layer_name, doc_type, doc_id]), 'layer': layer}
 
     def bulk_put(self, layers, layer_name, doc_type, root_doc_id):
         """Store all layer objects. Note this does not delete existing docs;
@@ -85,7 +85,7 @@ class ESLayers(ESBase, interface.Layers):
 
     def get(self, name, doc_type, doc_id):
         """Find the layer that matches these parameters"""
-        reference = ':'.join(name, doc_type, self.sanitize_doc_id(doc_id))
+        reference = ':'.join([name, doc_type, self.sanitize_doc_id(doc_id)])
         layer = self.safe_fetch('layer', reference)
         if layer is not None:
             return layer['layer']

--- a/regcore/db/es.py
+++ b/regcore/db/es.py
@@ -66,23 +66,27 @@ class ESRegulations(ESBase, interface.Regulations):
 
 class ESLayers(ESBase, interface.Layers):
     """Implementation of Elastic Search as layers backend"""
-    def _transform(self, layer, layer_name):
+    def _transform(self, layer, layer_name, doc_type):
         """Add some meta data fields which are ES specific"""
         layer = dict(layer)     # copy
-        reference = layer['reference']
-        del layer['reference']
-        return {'id': '{}:{}'.format(layer_name, reference), 'layer': layer}
+        doc_id = self.sanitize_doc_id(layer['doc_id'])
+        del layer['doc_id']
+        return {'id': ':'.join(layer_name, doc_type, doc_id), 'layer': layer}
 
-    def bulk_put(self, layers, layer_name, prefix):
+    def bulk_put(self, layers, layer_name, doc_type, root_doc_id):
         """Store all layer objects. Note this does not delete existing docs;
         it only replaces/inserts docs, which has loop holes"""
         self.es.bulk_index(
             settings.ELASTIC_SEARCH_INDEX, 'layer',
-            [self._transform(l, layer_name) for l in layers])
+            [self._transform(l, layer_name, doc_type) for l in layers])
 
-    def get(self, name, reference):
+    def sanitize_doc_id(self, doc_id):
+        return ':'.join(doc_id.split('/'))
+
+    def get(self, name, doc_type, doc_id):
         """Find the layer that matches these parameters"""
-        layer = self.safe_fetch('layer', name + ':' + reference)
+        reference = ':'.join(name, doc_type, self.sanitize_doc_id(doc_id))
+        layer = self.safe_fetch('layer', reference)
         if layer is not None:
             return layer['layer']
 

--- a/regcore/db/interface.py
+++ b/regcore/db/interface.py
@@ -26,18 +26,18 @@ class Regulations(object):
 
 @six.add_metaclass(abc.ABCMeta)
 class Layers(object):
-    def bulk_put(self, layers, layer_name, prefix):
+    def bulk_put(self, layers, layer_name, doc_type, root_doc_id):
         """Add multiple entries with the same layer_name.
         :param list[dict] layers: Each dictionary represents a layer; each
-        should have a distinct "reference", which will be used during
-        insertion.
+        should have a distinct "doc_id", which will be used during insertion.
         :param str layer_name: Identifier for this layer, e.g. "toc",
         "internal-citations", etc.
-        :param str prefix: All layer entries with this prefix should be
-        deleted before inserting"""
+        :param str doc_type: layers are keyed by doc_type
+        :param str root_doc_id: the doc id of the "root" layer. This is used
+        to delete existing data before inserting"""
         raise NotImplementedError
 
-    def get(self, name, reference):
+    def get(self, name, doc_type, doc_id):
         """Return a single layer (no meta data) or None"""
         raise NotImplementedError
 

--- a/regcore/layer.py
+++ b/regcore/layer.py
@@ -1,22 +1,23 @@
-class LayerParams(object):
+from collections import namedtuple
+
+LayerParams = namedtuple('LayerParams', ['doc_type', 'doc_id', 'tree_id'])
+
+
+# @todo Remove in a future release
+def standardize_params(doc_type, doc_id):
     """We need to convert between an older form of url params,
         /layer/{layer type}/{reg label id}/{version id}
     and a new form:
         /layer/{layer type}/{doc type}/{doc id which may contain more slashes}
     This class handles that conversion and provides a single interface for
     both forms"""
-    def __init__(self, doc_type, doc_id):
-        # old format - we can remove once all data/libs are migrated
-        if doc_type not in ('preamble', 'cfr'):
-            # this looks backwards, but it's the format we assumed before
-            label, version = doc_type, doc_id
-            doc_type = 'cfr'
-            doc_id = '/'.join([version, label])
+    # old format - we can remove once all data/libs are migrated
+    if doc_type not in ('preamble', 'cfr'):
+        # this looks backwards, but it's the format we assumed before
+        label, version = doc_type, doc_id
+        doc_type = 'cfr'
+        doc_id = '/'.join([version, label])
 
-        self.doc_type = doc_type
-        self.doc_id = doc_id
-
-    @property
-    def tree_id(self):
-        """Return "111_22" in both doc_ids, "111_22" and "version/111_22" """
-        return self.doc_id.split('/')[-1]
+    # e.g. "111_22" in both doc_ids, "111_22" and "version/111_22"
+    tree_id = doc_id.split('/')[-1]
+    return LayerParams(doc_type, doc_id,  tree_id)

--- a/regcore/layer.py
+++ b/regcore/layer.py
@@ -1,0 +1,22 @@
+class LayerParams(object):
+    """We need to convert between an older form of url params,
+        /layer/{layer type}/{reg label id}/{version id}
+    and a new form:
+        /layer/{layer type}/{doc type}/{doc id which may contain more slashes}
+    This class handles that conversion and provides a single interface for
+    both forms"""
+    def __init__(self, doc_type, doc_id):
+        # old format - we can remove once all data/libs are migrated
+        if doc_type not in ('preamble', 'cfr'):
+            # this looks backwards, but it's the format we assumed before
+            label, version = doc_type, doc_id
+            doc_type = 'cfr'
+            doc_id = '/'.join([version, label])
+
+        self.doc_type = doc_type
+        self.doc_id = doc_id
+
+    @property
+    def tree_id(self):
+        """Return "111_22" in both doc_ids, "111_22" and "version/111_22" """
+        return self.doc_id.split('/')[-1]

--- a/regcore/migrations/0009_auto_20160322_1646.py
+++ b/regcore/migrations/0009_auto_20160322_1646.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('regcore', '0008_auto_20160314_1144'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='layer',
+            old_name='reference',
+            new_name='doc_id',
+        ),
+        migrations.AddField(
+            model_name='layer',
+            name='doc_type',
+            field=models.SlugField(default='cfr', max_length=20),
+            preserve_default=False,
+        ),
+        migrations.AlterUniqueTogether(
+            name='layer',
+            unique_together=set([('name', 'doc_type', 'doc_id')]),
+        ),
+        migrations.AlterIndexTogether(
+            name='layer',
+            index_together=set([('name', 'doc_type', 'doc_id')]),
+        ),
+    ]

--- a/regcore/migrations/0010_auto_20160322_1704.py
+++ b/regcore/migrations/0010_auto_20160322_1704.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def forward(apps, schema_editor):
+    schema_editor.execute("""
+        UPDATE regcore_layer SET doc_id=REPLACE(doc_id, ':', '/')
+        WHERE doc_type='cfr';
+    """)
+
+
+def backward(apps, schema_editor):
+    schema_editor.execute("""
+        UPDATE regcore_layer SET doc_id=REPLACE(doc_id, '/', ':')
+        WHERE doc_type='cfr';
+    """)
+
+
+class Migration(migrations.Migration):
+    """Convert doc_ids like 11_22:33-44-aa into 11_22/33-44-aa"""
+
+    dependencies = [
+        ('regcore', '0009_auto_20160322_1646'),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, backward)
+    ]

--- a/regcore/models.py
+++ b/regcore/models.py
@@ -24,6 +24,10 @@ class Layer(models.Model):
     name = models.SlugField(max_length=20)
     layer = CompressedJSONField()
     doc_type = models.SlugField(max_length=20)
+    # We allow doc_ids to contain slashes, which are particularly important
+    # for CFR docs, which use the [version_id]/[reg_label_id] format. It might
+    # make sense to split off a version identifier into a separate field in
+    # the future, if we can't treat that doc_id as an opaque string
     doc_id = models.SlugField(max_length=250)
 
     class Meta:

--- a/regcore/models.py
+++ b/regcore/models.py
@@ -23,10 +23,11 @@ class Regulation(MPTTModel):
 class Layer(models.Model):
     name = models.SlugField(max_length=20)
     layer = CompressedJSONField()
-    reference = models.SlugField(max_length=250)
+    doc_type = models.SlugField(max_length=20)
+    doc_id = models.SlugField(max_length=250)
 
     class Meta:
-        index_together = (('name', 'reference'),)
+        index_together = (('name', 'doc_type', 'doc_id'),)
         unique_together = index_together
 
 

--- a/regcore/tests/db_django_models_tests.py
+++ b/regcore/tests/db_django_models_tests.py
@@ -75,33 +75,33 @@ class DMLayersTest(TestCase):
         self.dml = DMLayers()
 
     def test_get_404(self):
-        self.assertIsNone(self.dml.get('namnam', 'cfr', 'verver:lablab'))
+        self.assertIsNone(self.dml.get('namnam', 'cfr', 'verver/lablab'))
 
     def test_get_success(self):
-        Layer(name='namnam', doc_type='cfr', doc_id='verver:lablab',
+        Layer(name='namnam', doc_type='cfr', doc_id='verver/lablab',
               layer={"some": "body"}).save()
 
         self.assertEqual({"some": 'body'},
-                         self.dml.get('namnam', 'cfr', 'verver:lablab'))
+                         self.dml.get('namnam', 'cfr', 'verver/lablab'))
 
     def test_bulk_put(self):
         """Writing multiple documents should save correctly. They can be
         modified"""
-        layers = [{'111-22': [], '111-22-a': [], 'doc_id': 'verver:111-22'},
-                  {'111-23': [], 'doc_id': 'verver:111-23'}]
-        self.dml.bulk_put(layers, 'name', 'cfr', 'verver:111')
+        layers = [{'111-22': [], '111-22-a': [], 'doc_id': 'verver/111-22'},
+                  {'111-23': [], 'doc_id': 'verver/111-23'}]
+        self.dml.bulk_put(layers, 'name', 'cfr', 'verver/111')
 
         self.assertEqual(Layer.objects.count(), 2)
-        self.assertEqual(self.dml.get('name', 'cfr', 'verver:111-22'),
+        self.assertEqual(self.dml.get('name', 'cfr', 'verver/111-22'),
                          {'111-22': [], '111-22-a': []})
-        self.assertEqual(self.dml.get('name', 'cfr', 'verver:111-23'),
+        self.assertEqual(self.dml.get('name', 'cfr', 'verver/111-23'),
                          {'111-23': []})
 
-        layers[1] = {'111-23': [1], 'doc_id': 'verver:111-23'}
-        self.dml.bulk_put(layers, 'name', 'cfr', 'verver:111')
+        layers[1] = {'111-23': [1], 'doc_id': 'verver/111-23'}
+        self.dml.bulk_put(layers, 'name', 'cfr', 'verver/111')
 
         self.assertEqual(Layer.objects.count(), 2)
-        self.assertEqual(self.dml.get('name', 'cfr', 'verver:111-23'),
+        self.assertEqual(self.dml.get('name', 'cfr', 'verver/111-23'),
                          {'111-23': [1]})
 
 

--- a/regcore/tests/db_django_models_tests.py
+++ b/regcore/tests/db_django_models_tests.py
@@ -75,33 +75,33 @@ class DMLayersTest(TestCase):
         self.dml = DMLayers()
 
     def test_get_404(self):
-        self.assertIsNone(self.dml.get('namnam', 'verver:lablab'))
+        self.assertIsNone(self.dml.get('namnam', 'cfr', 'verver:lablab'))
 
     def test_get_success(self):
-        Layer(name='namnam', reference='verver:lablab',
+        Layer(name='namnam', doc_type='cfr', doc_id='verver:lablab',
               layer={"some": "body"}).save()
 
         self.assertEqual({"some": 'body'},
-                         self.dml.get('namnam', 'verver:lablab'))
+                         self.dml.get('namnam', 'cfr', 'verver:lablab'))
 
     def test_bulk_put(self):
         """Writing multiple documents should save correctly. They can be
         modified"""
-        layers = [{'111-22': [], '111-22-a': [], 'reference': 'verver:111-22'},
-                  {'111-23': [], 'reference': 'verver:111-23'}]
-        self.dml.bulk_put(layers, 'name', 'verver:111')
+        layers = [{'111-22': [], '111-22-a': [], 'doc_id': 'verver:111-22'},
+                  {'111-23': [], 'doc_id': 'verver:111-23'}]
+        self.dml.bulk_put(layers, 'name', 'cfr', 'verver:111')
 
         self.assertEqual(Layer.objects.count(), 2)
-        self.assertEqual(self.dml.get('name', 'verver:111-22'),
+        self.assertEqual(self.dml.get('name', 'cfr', 'verver:111-22'),
                          {'111-22': [], '111-22-a': []})
-        self.assertEqual(self.dml.get('name', 'verver:111-23'),
+        self.assertEqual(self.dml.get('name', 'cfr', 'verver:111-23'),
                          {'111-23': []})
 
-        layers[1] = {'111-23': [1], 'reference': 'verver:111-23'}
-        self.dml.bulk_put(layers, 'name', 'verver:111')
+        layers[1] = {'111-23': [1], 'doc_id': 'verver:111-23'}
+        self.dml.bulk_put(layers, 'name', 'cfr', 'verver:111')
 
         self.assertEqual(Layer.objects.count(), 2)
-        self.assertEqual(self.dml.get('name', 'verver:111-23'),
+        self.assertEqual(self.dml.get('name', 'cfr', 'verver:111-23'),
                          {'111-23': [1]})
 
 

--- a/regcore/tests/db_es_tests.py
+++ b/regcore/tests/db_es_tests.py
@@ -106,25 +106,26 @@ class ESRegulationsTest(TestCase, ESBase):
 
 class ESLayersTest(TestCase, ESBase):
     def test_get_404(self):
-        with self.expect_get('layer', 'namnam:verver:lablab'):
-            self.assertIsNone(ESLayers().get('namnam', 'verver:lablab'))
+        with self.expect_get('layer', 'namnam:cfr:verver:lablab'):
+            self.assertIsNone(
+                ESLayers().get('namnam', 'cfr', 'verver:lablab'))
 
     def test_get_success(self):
-        return_value = {'layer': {'some': 'body'}}
-        with self.expect_get('layer', 'namnam:verver:lablab', return_value):
-            self.assertEqual(ESLayers().get('namnam', 'verver:lablab'),
+        with self.expect_get('layer', 'namnam:cfr:verver:lablab',
+                             {'layer': {'some': 'body'}}):
+            self.assertEqual(ESLayers().get('namnam', 'cfr', 'verver:lablab'),
                              {"some": "body"})
 
     def test_bulk_put(self):
-        layers = [{'111-22': [], '111-22-a': [], 'reference': 'verver:111-22'},
-                  {'111-23': [], 'reference': 'verver:111-23'}]
+        layers = [{'111-22': [], '111-22-a': [], 'doc_id': 'verver:111-22'},
+                  {'111-23': [], 'doc_id': 'verver:111-23'}]
         with self.expect_bulk_put('layer', 2) as bulk_put:
-            ESLayers().bulk_put(layers, 'name', 'verver:111')
+            ESLayers().bulk_put(layers, 'name', 'cfr', 'verver:111')
 
-        del layers[0]['reference']
-        del layers[1]['reference']
-        transformed = [{'id': 'name:verver:111-22', 'layer': layers[0]},
-                       {'id': 'name:verver:111-23', 'layer': layers[1]}]
+        del layers[0]['doc_id']
+        del layers[1]['doc_id']
+        transformed = [{'id': 'name:cfr:verver:111-22', 'layer': layers[0]},
+                       {'id': 'name:cfr:verver:111-23', 'layer': layers[1]}]
         self.assertEqual(transformed, bulk_put.call_args[0][2])
 
 

--- a/regcore/tests/layer_tests.py
+++ b/regcore/tests/layer_tests.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+
+from regcore.layer import LayerParams
+
+
+class LayerParamsTests(TestCase):
+    def test_old_format(self):
+        lp = LayerParams('label', 'version')
+        self.assertEqual(lp.doc_type, 'cfr')
+        self.assertEqual(lp.doc_id, 'version/label')
+        self.assertEqual(lp.tree_id, 'label')
+
+    def test_new_format(self):
+        lp = LayerParams('cfr', 'version/label')
+        self.assertEqual(lp.doc_type, 'cfr')
+        self.assertEqual(lp.doc_id, 'version/label')
+        self.assertEqual(lp.tree_id, 'label')
+
+        lp = LayerParams('preamble', 'docid')
+        self.assertEqual(lp.doc_type, 'preamble')
+        self.assertEqual(lp.doc_id, 'docid')
+        self.assertEqual(lp.tree_id, 'docid')

--- a/regcore/tests/layer_tests.py
+++ b/regcore/tests/layer_tests.py
@@ -1,22 +1,22 @@
 from django.test import TestCase
 
-from regcore.layer import LayerParams
+from regcore.layer import standardize_params
 
 
 class LayerParamsTests(TestCase):
     def test_old_format(self):
-        lp = LayerParams('label', 'version')
+        lp = standardize_params('label', 'version')
         self.assertEqual(lp.doc_type, 'cfr')
         self.assertEqual(lp.doc_id, 'version/label')
         self.assertEqual(lp.tree_id, 'label')
 
     def test_new_format(self):
-        lp = LayerParams('cfr', 'version/label')
+        lp = standardize_params('cfr', 'version/label')
         self.assertEqual(lp.doc_type, 'cfr')
         self.assertEqual(lp.doc_id, 'version/label')
         self.assertEqual(lp.tree_id, 'label')
 
-        lp = LayerParams('preamble', 'docid')
+        lp = standardize_params('preamble', 'docid')
         self.assertEqual(lp.doc_type, 'preamble')
         self.assertEqual(lp.doc_id, 'docid')
         self.assertEqual(lp.tree_id, 'docid')

--- a/regcore/urls.py
+++ b/regcore/urls.py
@@ -44,7 +44,7 @@ if 'regcore_write' in settings.INSTALLED_APPS:
 
 # Re-usable URL patterns.
 def seg(label):
-    return r'(?P<%s>[-\d\w]+)' % label
+    return r'(?P<%s>[-\w]+)' % label
 
 
 urlpatterns = patterns(
@@ -52,9 +52,9 @@ urlpatterns = patterns(
     by_verb_url(r'^diff/%s/%s/%s$' % (seg('label_id'), seg('old_version'),
                                       seg('new_version')),
                 'diff', mapping['diff']),
-    by_verb_url(r'^layer/%s/%s(/%s)?$' % (seg('name'), seg('label_id'),
-                                          seg('version')),
-                'layer', mapping['layer']),
+    by_verb_url(r'^layer/{}/{}/{}$'.format(
+        seg('name'), seg('doc_type'), r'(?P<doc_id>[-\w]+(/[-\w]+)*)'),
+        'layer', mapping['layer']),
     by_verb_url(r'^notice/%s$' % seg('docnum'),
                 'notice', mapping['notice']),
     by_verb_url(r'^regulation/%s/%s$' % (seg('label_id'), seg('version')),

--- a/regcore_read/tests/views_layer_tests.py
+++ b/regcore_read/tests/views_layer_tests.py
@@ -8,7 +8,7 @@ class ViewsLayerTest(TestCase):
 
     @patch('regcore_read.views.layer.storage')
     def test_get_none(self, storage):
-        url = '/layer/layname/lablab/verver'
+        url = '/layer/layname/cfr/verver/lablab'
 
         storage.for_layers.get.return_value = None
         response = self.client.get(url)
@@ -19,16 +19,16 @@ class ViewsLayerTest(TestCase):
         """Verify that a request to GET a specific layer hits the backend with
         appropriate version info"""
         storage.for_layers.get.return_value = {'example': 'response'}
-        response = self.client.get('/layer/nnn/lll/vvv')
+        response = self.client.get('/layer/nnn/cfr/vvv/lll')
         self.assertEqual(200, response.status_code)
         self.assertEqual(storage.for_layers.get.call_args[0],
-                         ('nnn', 'vvv:lll'))
+                         ('nnn', 'cfr', 'vvv/lll'))
         self.assertEqual({'example': 'response'},
                          json.loads(response.content.decode('utf-8')))
 
-        response = self.client.get('/layer/nnn/lll')
+        response = self.client.get('/layer/nnn/preamble/lll')
         self.assertEqual(storage.for_layers.get.call_args[0],
-                         ('nnn', 'lll'))
+                         ('nnn', 'preamble', 'lll'))
         self.assertEqual(200, response.status_code)
         self.assertEqual({'example': 'response'},
                          json.loads(response.content.decode('utf-8')))
@@ -36,6 +36,6 @@ class ViewsLayerTest(TestCase):
     @patch('regcore_read.views.layer.storage')
     def test_get_results_empty_layer(self, storage):
         storage.for_layers.get.return_value = {}
-        response = self.client.get('/layer/nnn/lll/vvv')
+        response = self.client.get('/layer/nnn/cfr/vvv/lll')
         self.assertEqual(200, response.status_code)
         self.assertEqual({}, json.loads(response.content.decode('utf-8')))

--- a/regcore_read/views/layer.py
+++ b/regcore_read/views/layer.py
@@ -1,14 +1,12 @@
 from regcore.db import storage
+from regcore.layer import LayerParams
 from regcore.responses import four_oh_four, success
 
 
-def get(request, name, label_id, version=None):
-    """Find and return the layer with this name + version + label"""
-    if version is None:
-        reference = label_id
-    else:
-        reference = '{}:{}'.format(version, label_id)
-    layer = storage.for_layers.get(name, reference)
+def get(request, name, doc_type, doc_id):
+    """Find and return the layer with this name, referring to this doc_id"""
+    params = LayerParams(doc_type, doc_id)
+    layer = storage.for_layers.get(name, params.doc_type, params.doc_id)
     if layer is not None:
         return success(layer)
     else:

--- a/regcore_read/views/layer.py
+++ b/regcore_read/views/layer.py
@@ -1,11 +1,11 @@
 from regcore.db import storage
-from regcore.layer import LayerParams
+from regcore.layer import standardize_params
 from regcore.responses import four_oh_four, success
 
 
 def get(request, name, doc_type, doc_id):
     """Find and return the layer with this name, referring to this doc_id"""
-    params = LayerParams(doc_type, doc_id)
+    params = standardize_params(doc_type, doc_id)
     layer = storage.for_layers.get(name, params.doc_type, params.doc_id)
     if layer is not None:
         return success(layer)

--- a/regcore_write/tests/views_layer_tests.py
+++ b/regcore_write/tests/views_layer_tests.py
@@ -3,7 +3,7 @@ import json
 from django.test import TestCase
 from mock import patch
 
-from regcore.layer import LayerParams
+from regcore.layer import standardize_params
 from regcore_write.views import layer
 
 
@@ -155,7 +155,7 @@ class ViewsLayerTest(TestCase):
     def test_child_layers_no_results(self, storage):
         """If the db returns no regulation data, nothing should get saved"""
         storage.for_regulations.get.return_value = None
-        layer_params = LayerParams('cfr', 'vvv/lll')
+        layer_params = standardize_params('cfr', 'vvv/lll')
         self.assertEqual([], layer.child_layers(layer_params, {}))
         self.assertTrue(storage.for_regulations.get.called)
         lab, ver = storage.for_regulations.get.call_args[0]
@@ -163,7 +163,7 @@ class ViewsLayerTest(TestCase):
         self.assertEqual('vvv', ver)
 
         storage.for_preambles.get.return_value = None
-        layer_params = LayerParams('preamble', 'docdoc')
+        layer_params = standardize_params('preamble', 'docdoc')
         self.assertEqual([], layer.child_layers(layer_params, {}))
         self.assertTrue(storage.for_preambles.get.called)
         self.assertEqual(('docdoc',), storage.for_preambles.get.call_args[0])

--- a/regcore_write/tests/views_layer_tests.py
+++ b/regcore_write/tests/views_layer_tests.py
@@ -3,13 +3,15 @@ import json
 from django.test import TestCase
 from mock import patch
 
+from regcore.layer import LayerParams
 from regcore_write.views import layer
 
 
 class ViewsLayerTest(TestCase):
-    def put(self, data, name='layname', label='lablab', version='verver'):
+    def put(self, data, name='layname', doc_type='cfr',
+            doc_id='verver/lablab'):
         """Shorthand function for PUTing data to a view layer"""
-        url = '/layer/{}/{}/{}'.format(name, label, version)
+        url = '/layer/{}/{}/{}'.format(name, doc_type, doc_id)
         if isinstance(data, dict):
             data = json.dumps(data)
         return self.client.put(url, content_type='application/json',
@@ -22,7 +24,7 @@ class ViewsLayerTest(TestCase):
 
     def test_add_label_mismatch(self):
         """Root label must match that found in the url"""
-        response = self.put({'nonlab': []}, label='lablab')
+        response = self.put({'nonlab': []}, doc_id='verver/lablab')
         self.assertEqual(400, response.status_code)
 
     def put_with_mock_data(self, message, *labels, **kwargs):
@@ -51,17 +53,18 @@ class ViewsLayerTest(TestCase):
             'lablab-b-4': [3, 4],
         }
         l1, l2, l3 = self.put_with_mock_data(
-            message, 'lablab', 'lablab-b', 'lablab-b-4')
+            message, 'lablab', 'lablab-b', 'lablab-b-4', doc_type='cfr',
+            doc_id='verver/lablab')
 
-        message['reference'] = 'verver:lablab'
+        message['doc_id'] = 'verver/lablab'
         self.assertEqual(message, l1)
 
         #   Sub layers have fewer elements
         del message['lablab']
-        message['reference'] = 'verver:lablab-b'
+        message['doc_id'] = 'verver/lablab-b'
         self.assertEqual(message, l2)
         del message['lablab-b']
-        message['reference'] = 'verver:lablab-b-4'
+        message['doc_id'] = 'verver/lablab-b-4'
         self.assertEqual(message, l3)
 
     def test_add_skip_level(self):
@@ -73,13 +76,13 @@ class ViewsLayerTest(TestCase):
         l1, l2, l3 = self.put_with_mock_data(
             message, 'lablab', 'lablab-b', 'lablab-b-4')
 
-        message['reference'] = 'verver:lablab'
+        message['doc_id'] = 'verver/lablab'
         self.assertEqual(message, l1)
         #   Sub layers have fewer elements
         del message['lablab']
-        message['reference'] = 'verver:lablab-b'
+        message['doc_id'] = 'verver/lablab-b'
         self.assertEqual(message, l2)
-        message['reference'] = 'verver:lablab-b-4'
+        message['doc_id'] = 'verver/lablab-b-4'
         self.assertEqual(message, l3)
 
     def test_add_interp_children(self):
@@ -87,7 +90,7 @@ class ViewsLayerTest(TestCase):
         message = {'99-5-Interp': [1, 2], '99-5-a-Interp': [3, 4]}
         l1, l2, l3, l4 = self.put_with_mock_data(
             message, '99', '99-Interp', '99-5-Interp', '99-5-a-Interp',
-            label='99')
+            doc_id='verver/99')
         for saved in (l1, l2, l3):
             self.assertIn('99-5-Interp', saved)
             self.assertIn('99-5-a-Interp', saved)
@@ -98,7 +101,8 @@ class ViewsLayerTest(TestCase):
         """Can correctly add layer data to subparts"""
         message = {'99-1': [1, 2], '99-1-a': [3, 4]}
         l1, l2, l3, l4 = self.put_with_mock_data(
-            message, '99', '99-Subpart-A', '99-1', '99-1-a', label='99')
+            message, '99', '99-Subpart-A', '99-1', '99-1-a',
+            doc_id='verver/99')
         for saved in (l1, l2, l3):
             self.assertIn('99-1', saved)
             self.assertIn('99-1-a', saved)
@@ -109,7 +113,8 @@ class ViewsLayerTest(TestCase):
         """The 'referenced' key is special; it should get added"""
         message = {'99-1': [1, 2], '99-1-a': [3, 4], 'referenced': [5, 6]}
         layers_saved = self.put_with_mock_data(
-            message, '99', '99-Subpart-A', '99-1', '99-1-a', label='99')
+            message, '99', '99-Subpart-A', '99-1', '99-1-a',
+            doc_id='verver/99')
         self.assertEqual(4, len(layers_saved))
         self.assertTrue(all('referenced' in saved for saved in layers_saved))
 
@@ -132,29 +137,36 @@ class ViewsLayerTest(TestCase):
                 ])])
         message = {'111_22': 'layer1', '111_22-3': 'layer2',
                    '111_22-3-b': 'layer3'}
-        self.client.put('/layer/aname/111_22', data=json.dumps(message))
+        self.client.put('/layer/aname/preamble/111_22',
+                        data=json.dumps(message))
         stored = storage.for_layers.bulk_put.call_args[0][0]
         self.assertEqual(len(stored), 9)
         for label in ('111_22-1', '111_22-2', '111_22-2-a', '111_22-3-a',
                       '111_22-3-a-i', '111_22-3-b-i'):
-            self.assertIn({'reference': label}, stored)     # i.e. empty
-        self.assertIn({'reference': '111_22', '111_22': 'layer1',
+            self.assertIn({'doc_id': label}, stored)     # i.e. empty
+        self.assertIn({'doc_id': '111_22', '111_22': 'layer1',
                        '111_22-3': 'layer2', '111_22-3-b': 'layer3'}, stored)
-        self.assertIn({'reference': '111_22-3', '111_22-3': 'layer2',
+        self.assertIn({'doc_id': '111_22-3', '111_22-3': 'layer2',
                        '111_22-3-b': 'layer3'}, stored)
-        self.assertIn({'reference': '111_22-3-b', '111_22-3-b': 'layer3'},
+        self.assertIn({'doc_id': '111_22-3-b', '111_22-3-b': 'layer3'},
                       stored)
 
     @patch('regcore_write.views.layer.storage')
     def test_child_layers_no_results(self, storage):
         """If the db returns no regulation data, nothing should get saved"""
         storage.for_regulations.get.return_value = None
-        storage.for_preambles.get.return_value = None
-        self.assertEqual([], layer.child_layers('layname', 'lll', 'vvv', {}))
+        layer_params = LayerParams('cfr', 'vvv/lll')
+        self.assertEqual([], layer.child_layers(layer_params, {}))
         self.assertTrue(storage.for_regulations.get.called)
         lab, ver = storage.for_regulations.get.call_args[0]
         self.assertEqual('lll', lab)
         self.assertEqual('vvv', ver)
+
+        storage.for_preambles.get.return_value = None
+        layer_params = LayerParams('preamble', 'docdoc')
+        self.assertEqual([], layer.child_layers(layer_params, {}))
+        self.assertTrue(storage.for_preambles.get.called)
+        self.assertEqual(('docdoc',), storage.for_preambles.get.call_args[0])
 
     def test_child_label_of(self):
         """Correctly determine relationships between labels"""


### PR DESCRIPTION
This adds a `doc_type` field to layers, currently consisting of two values, 'cfr' and 'preamble' (preventing many potential collisions). This also modifies the URL pattern, which used to be
`/layer/[layername]/[regulation_label_id]/[version_id]`
to
`/layer/[layername]/[doc_type]/[doc_id-which-may-include-slashes]`
For backwards compatibility, this adds a translation layer between the old format and the new. It does, however, migrate existing data.

For eregs/notice-and-comment#17
