### PR TITLE
Allow node type to be longer

### DIFF
--- a/regcore/migrations/0014_auto_20160504_0101.py
+++ b/regcore/migrations/0014_auto_20160504_0101.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('regcore', '0013_remove_models'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='document',
+            name='node_type',
+            field=models.SlugField(max_length=30),
+        ),
+    ]

--- a/regcore/models.py
+++ b/regcore/models.py
@@ -13,7 +13,7 @@ class Document(MPTTModel):
     label_string = models.SlugField(max_length=200)
     text = models.TextField()
     title = models.TextField(blank=True)
-    node_type = models.SlugField(max_length=10)
+    node_type = models.SlugField(max_length=30)
     root = models.BooleanField(default=False, db_index=True)
 
     class Meta:


### PR DESCRIPTION
Our ten character limit was preventing "preamble_intro" from working
correctly. Up it to 30 to allow roughly double that length
