### PR TITLE
Add `lft` attribute to Django model

### DIFF
--- a/regcore/db/django_models.py
+++ b/regcore/db/django_models.py
@@ -66,6 +66,8 @@ class DMDocuments(interface.Documents):
                 for child in adjacency_map.get(reg.id, [])
             ],
         }
+        if reg.lft:
+            ret['lft'] = reg.lft
         if reg.title:
             ret['title'] = reg.title
         return ret

--- a/regcore/db/django_models.py
+++ b/regcore/db/django_models.py
@@ -66,8 +66,7 @@ class DMDocuments(interface.Documents):
                 for child in adjacency_map.get(reg.id, [])
             ],
         }
-        if reg.lft:
-            ret['lft'] = reg.lft
+        ret['lft'] = getattr(reg, 'lft', None)
         if reg.title:
             ret['title'] = reg.title
         return ret

--- a/regcore/tests/db_django_models_tests.py
+++ b/regcore/tests/db_django_models_tests.py
@@ -22,6 +22,7 @@ class DMDocumentsTest(TestCase):
             {
                 'text': 'ttt',
                 'label': ['a', 'b'],
+                'lft': 1,
                 'children': [],
                 'node_type': 'tyty'
             },
@@ -35,6 +36,7 @@ class DMDocumentsTest(TestCase):
             {
                 'text': 'ttt',
                 'label': ['a', 'b'],
+                'lft': 1,
                 'children': [],
                 'node_type': 'tyty'
             },
@@ -70,13 +72,20 @@ class DMDocumentsTest(TestCase):
 
     def test_bulk_put(self):
         """Writing multiple documents should save correctly. They can be
-        modified"""
-        n2 = {'text': 'some text', 'label': ['111', '2'], 'children': [],
-              'node_type': 'tyty'}
-        n3 = {'text': 'other', 'label': ['111', '3'], 'children': [],
+        modified. The lft and rght ids assigned by the Modified Preorder Tree
+        Traversal algorithm are shown below:
+
+                                (1)root(6)
+                                /    \
+                               /       \
+                         (2)n2(3)    (4)n3(5)
+        """
+        n2 = {'text': 'some text', 'label': ['111', '2'], 'lft': 2,
+              'children': [], 'node_type': 'tyty'}
+        n3 = {'text': 'other', 'label': ['111', '3'], 'children': [], 'lft': 4,
               'node_type': 'tyty2'}
-        root = {'text': 'root', 'label': ['111'], 'node_type': 'tyty3',
-                'children': [n2, n3]}
+        root = {'text': 'root', 'label': ['111'], 'lft': 1,
+                'node_type': 'tyty3', 'children': [n2, n3]}
         original = copy.deepcopy(root)
         n2['parent'] = root
         n3['parent'] = root

--- a/regcore_write/views/document.py
+++ b/regcore_write/views/document.py
@@ -26,8 +26,7 @@ REGULATION_SCHEMA = {
             'items': {'type': 'string'}
         },
         'title': {'type': 'string'},
-        'node_type': {'type': 'string'},
-        'preorder_idx': {'type': 'integer', 'minimum': 0}
+        'node_type': {'type': 'string'}
     }
 }
 


### PR DESCRIPTION
This attribute can be used to sort tree nodes in pre order.
Consequently, we do not need the preorder_idx field in the JSON schema.
