### PR TITLE
Add Django 1.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: python
 sudo: false
 python:
     - "2.7"
-    - "3.3"
     - "3.4"
     - "3.5"
     - "pypy"
     # - "3.2" pyelasticsearch is not compatible
+    # - "3.3" Django stopped supporting this in 1.9
     # - "pypy3" requires sudo in travis
 install:
     - pip install -r requirements.txt

--- a/regcore/settings/base.py
+++ b/regcore/settings/base.py
@@ -24,6 +24,11 @@ DATABASES = {
     }
 }
 
+TEMPLATES = [{
+    'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    'APP_DIRS': True,
+}]
+
 TEST_RUNNER = 'django_nose.runner.NoseTestSuiteRunner'
 
 ROOT_URLCONF = 'regcore.urls'

--- a/regcore/urls.py
+++ b/regcore/urls.py
@@ -6,7 +6,6 @@ and regcore_write apps"""
 from collections import defaultdict
 
 from django.conf import settings
-from django.conf.urls import patterns
 
 from regcore_read.views import (
     diff as rdiff, layer as rlayer, notice as rnotice,
@@ -47,8 +46,7 @@ def seg(label):
     return r'(?P<%s>[-\w]+)' % label
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     by_verb_url(r'^diff/%s/%s/%s$' % (seg('label_id'), seg('old_version'),
                                       seg('new_version')),
                 'diff', mapping['diff']),
@@ -72,4 +70,4 @@ urlpatterns = patterns(
                 kwargs={'doc_type': 'cfr'}),
     by_verb_url(r'^search/preamble$', 'search', mapping['search'],
                 kwargs={'doc_type': 'preamble'}),
-)
+]

--- a/regcore_read/tests/urls.py
+++ b/regcore_read/tests/urls.py
@@ -1,14 +1,13 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from regcore_read.views import es_search, haystack_search
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^es_search$', es_search.search, kwargs={'doc_type': 'cfr'}),
     url(
         r'^haystack_search$',
         haystack_search.search,
         kwargs={'doc_type': 'cfr'},
     ),
-)
+]

--- a/regcore_read/tests/views_es_search_tests.py
+++ b/regcore_read/tests/views_es_search_tests.py
@@ -1,12 +1,11 @@
-from django.test import TestCase
+from django.test import override_settings, TestCase
 from django.test.client import Client
 from mock import patch
 from regcore_read.views.es_search import transform_results
 
 
+@override_settings(ROOT_URLCONF='regcore_read.tests.urls')
 class ViewsESSearchTest(TestCase):
-    urls = 'regcore_read.tests.urls'
-
     def test_search_missing_q(self):
         response = Client().get('/es_search?non_q=test')
         self.assertEqual(400, response.status_code)

--- a/regcore_read/tests/views_haystack_search_tests.py
+++ b/regcore_read/tests/views_haystack_search_tests.py
@@ -1,15 +1,14 @@
 from collections import namedtuple
 
-from django.test import TestCase
+from django.test import override_settings, TestCase
 from django.test.client import Client
 from mock import patch
 
 from regcore_read.views.haystack_search import transform_results
 
 
+@override_settings(ROOT_URLCONF='regcore_read.tests.urls')
 class ViewsHaystackSearchTest(TestCase):
-    urls = 'regcore_read.tests.urls'
-
     def test_search_missing_q(self):
         response = Client().get('/haystack_search?non_q=test')
         self.assertEqual(400, response.status_code)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     license="public domain",
     packages=find_packages(),
     install_requires=[
-        'django>=1.8,<1.9',
+        'django>=1.8,<1.10',
         'django-mptt',
         'jsonschema',
         'six',


### PR DESCRIPTION
This app would support 1.9 as is, but with some warning messages. This removes
those:
- empty TEMPLATES values have been deprecated, even if they are not used
- the `patterns` function has been deprecated. Using a list has worked since
  1.8
- defining a urls file in a test case via an attribute has been deprecated
