### PR TITLE
Bump to version 3.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="regcore",
-    version="3.0.0",
+    version="3.1.0",
     license="public domain",
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
# New features
* Django 1.10 and 1.11 support

# Misc
* Switch to tox for testing across multiple Django versions
* Drop requirements files to discourage running as an app