### PR TITLE
Allow environment config for ALLOWED_HOSTS.

### DIFF
--- a/regcore/settings/base.py
+++ b/regcore/settings/base.py
@@ -4,6 +4,10 @@ import os
 
 from django.utils.crypto import get_random_string
 
+ALLOWED_HOSTS = [
+    value for key, value in os.environ.items()
+    if key.startswith('ALLOWED_HOST')
+]
 
 INSTALLED_APPS = [
     'mptt',


### PR DESCRIPTION
Without this configuration, Django will only respond to localhost. That's a
problem when ran inside Docker.