### PR TITLE
Split dependencies of backends during tests.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk --update add ca-certificates \
     && update-ca-certificates \
     && rm -rf /var/cache/apk/*
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -e .[all-backends] \
+    && pip install --no-cache-dir -e .[backend-haystack] \
     && python manage.py migrate
 
 ENV PYTHONUNBUFFERED="1"

--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ rebuild the search index (`manage.py rebuild_index`) after adding documents.
 
 ### Elastic Search For Data and Search
 
-If *pyelasticsearch* is installed, you can use Elastic Search (1.7) for both
-data storage and search. Add the following to your settings file:
+If *pyelasticsearch* is installed (e.g. through `pip install
+regcore[backend-elastic]`), you can use Elastic Search (1.7) for both data
+storage and search. Add the following to your settings file:
 
 ```python
 BACKENDS = {
@@ -157,6 +158,8 @@ BACKENDS = {
 }
 SEARCH_HANDLER = 'regcore_read.views.es_search.search'
 ```
+
+You may wish to extend the `regcore.settings.elastic` module for simplicity.
 
 
 ## Settings

--- a/regcore/db/es.py
+++ b/regcore/db/es.py
@@ -2,6 +2,7 @@
 etc.), implemented using Elastic Search as a data store"""
 import logging
 
+from cached_property import cached_property
 from django.conf import settings
 from pyelasticsearch import ElasticSearch
 from pyelasticsearch.exceptions import ElasticHttpNotFoundError
@@ -18,8 +19,10 @@ def sanitize_doc_id(doc_id):
 
 class ESBase(object):
     """Shared code for Elastic Search storage models"""
-    def __init__(self):
-        self.es = ElasticSearch(settings.ELASTIC_SEARCH_URLS)
+
+    @cached_property
+    def es(self):
+        return ElasticSearch(settings.ELASTIC_SEARCH_URLS)
 
     def safe_fetch(self, doc_type, es_id):
         """Attempt to retrieve a document from Elastic Search.

--- a/regcore/settings/elastic.py
+++ b/regcore/settings/elastic.py
@@ -1,0 +1,10 @@
+from regcore.settings.base import *     # noqa
+
+INSTALLED_APPS.remove('haystack')
+BACKENDS = {
+    'regulations': 'regcore.db.es.ESRegulations',
+    'layers': 'regcore.db.es.ESLayers',
+    'notices': 'regcore.db.es.ESNotices',
+    'diffs': 'regcore.db.es.ESDiffs'
+}
+SEARCH_HANDLER = 'regcore_read.views.es_search.search'

--- a/regcore/tests/db_es_tests.py
+++ b/regcore/tests/db_es_tests.py
@@ -1,7 +1,9 @@
 from contextlib import contextmanager
 from unittest import TestCase
 
+import pytest
 from mock import patch
+pytest.importorskip('pyelasticsearch')  # noqa
 from pyelasticsearch.exceptions import ElasticHttpNotFoundError
 
 from regcore.db.es import ESDiffs, ESDocuments, ESLayers, ESNotices

--- a/regcore/tests/index_tests.py
+++ b/regcore/tests/index_tests.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
 
+import pytest
 from mock import patch
+pytest.importorskip('pyelasticsearch')  # noqa
 from pyelasticsearch.exceptions import IndexAlreadyExistsError
 
 from regcore.index import init_schema

--- a/regcore_read/tests/views_es_search_tests.py
+++ b/regcore_read/tests/views_es_search_tests.py
@@ -1,21 +1,23 @@
+import pytest
 from django.test import TestCase, override_settings
 from django.test.client import Client
 from mock import patch
 
+pytest.importorskip('pyelasticsearch')  # noqa
 from regcore_read.views.es_search import transform_results
 
 
-@override_settings(ROOT_URLCONF='regcore_read.tests.urls')
+@override_settings(SEARCH_HANDLER='regcore_read.views.es_search.search')
 class ViewsESSearchTest(TestCase):
     def test_search_missing_q(self):
-        response = Client().get('/es_search?non_q=test')
+        response = Client().get('/search?non_q=test')
         self.assertEqual(400, response.status_code)
 
     @patch('regcore_read.views.es_search.ElasticSearch')
     def test_search_success(self, es):
         es.return_value.search.return_value = {'hits': {'hits': [],
                                                         'total': 0}}
-        response = Client().get('/es_search?q=test')
+        response = Client().get('/search?q=test')
         self.assertEqual(200, response.status_code)
         self.assertTrue(es.called)
         self.assertTrue(es.return_value.search.called)
@@ -24,7 +26,7 @@ class ViewsESSearchTest(TestCase):
     def test_search_version(self, es):
         es.return_value.search.return_value = {'hits': {'hits': [],
                                                         'total': 0}}
-        response = Client().get('/es_search?q=test&version=12345678')
+        response = Client().get('/search?q=test&version=12345678')
         self.assertEqual(200, response.status_code)
         self.assertTrue(es.called)
         self.assertTrue(es.return_value.search.called)
@@ -34,7 +36,7 @@ class ViewsESSearchTest(TestCase):
     def test_search_version_regulation(self, es):
         es.return_value.search.return_value = {'hits': {'hits': [],
                                                         'total': 0}}
-        response = Client().get('/es_search?q=test&version=678&regulation=123')
+        response = Client().get('/search?q=test&version=678&regulation=123')
         self.assertEqual(200, response.status_code)
         self.assertTrue(es.called)
         self.assertTrue(es.return_value.search.called)
@@ -45,7 +47,7 @@ class ViewsESSearchTest(TestCase):
     def test_search_paging(self, es):
         es.return_value.search.return_value = {'hits': {'hits': [],
                                                         'total': 0}}
-        response = Client().get('/es_search?q=test&page=5')
+        response = Client().get('/search?q=test&page=5')
         self.assertEqual(200, response.status_code)
         self.assertTrue(es.called)
         self.assertTrue(es.return_value.search.called)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     ],
     extras_require={
         'backend-elastic': ['pyelasticsearch'],
-        'backend-django': ['django-haystack'],
-        'all-backends': ['django-haystack', 'pyelasticsearch'],
+        'backend-haystack': ['django-haystack'],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
+        'cached_property',
         'django>=1.8,<1.12',
         'django-mptt',
         'jsonschema',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,py}-django{18,19,110,111}-{elastic,haystack},lint,docs
+envlist = clean,py{27,34,35,36,py}-django{18,19,110,111}-{elastic,haystack},lint,docs
 
 [testenv]
 deps =
@@ -17,9 +17,16 @@ deps =
 extras =
   elastic: backend-elastic
   haystack: backend-haystack
-commands = pytest --cov
+commands = pytest --cov --cov-append
 setenv =
   elastic: DJANGO_SETTINGS_MODULE = regcore.settings.elastic
+
+[testenv:clean]
+deps:
+  coverage~=4.0
+commands = coverage erase
+skip_install = True
+skipsdist = True
 
 [testenv:lint]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,py}-django{18,19,110,111},lint,docs
+envlist = py{27,34,35,36,py}-django{18,19,110,111}-{elastic,haystack},lint,docs
 
 [testenv]
 deps =
@@ -14,8 +14,12 @@ deps =
   pytest~=3.0
   pytest_cov~=2.4
   pytest_django~=3.1
-extras = all-backends
+extras =
+  elastic: backend-elastic
+  haystack: backend-haystack
 commands = pytest --cov
+setenv =
+  elastic: DJANGO_SETTINGS_MODULE = regcore.settings.elastic
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
We've been testing with both the haystack and elastic dependencies installed
at once. This will be a problem when working with the postgres backend because
it requires a specific version of Django. We'd like to keep testing the other
versions of Django with haystack and elastic, so we need to set up a framework
for testing separate backends with different dependencies installed.