### PR TITLE
Allow page_size to be requested by the user.

### DIFF
--- a/regcore_read/tests/views_seach_utils_tests.py
+++ b/regcore_read/tests/views_seach_utils_tests.py
@@ -1,0 +1,25 @@
+import pytest
+
+from regcore_read.views import search_utils
+
+
+def inner_fn(request, search_args):
+    # We'd generally return a Response here, but we're mocking
+    return search_args
+
+
+@pytest.mark.parametrize('page_size', ('-10', '0', '200', 'abcd', '---'))
+def test_invalid_page_size(page_size, rf):
+    """Invalid page sizes should not be admitted."""
+    view = search_utils.requires_search_args(inner_fn)
+    result = view(rf.get('?q=term&page_size={0}'.format(page_size)))
+    assert result.status_code == 400
+
+
+def test_valid_page_size(rf):
+    """Valid page sizes should pass through."""
+    view = search_utils.requires_search_args(inner_fn)
+    result = view(rf.get('?q=term'))
+
+    result = view(rf.get('?q=term&page_size=10'))
+    assert result.page_size == 10

--- a/regcore_read/views/es_search.py
+++ b/regcore_read/views/es_search.py
@@ -6,7 +6,7 @@ from pyelasticsearch import ElasticSearch
 
 from regcore.db.es import ESLayers
 from regcore.responses import success
-from regcore_read.views.search_utils import requires_search_args, PAGE_SIZE
+from regcore_read.views.search_utils import requires_search_args
 
 
 @requires_search_args
@@ -15,8 +15,8 @@ def search(request, doc_type, search_args):
     query = {
         'fields': ['text', 'label', 'version', 'regulation', 'title',
                    'label_string'],
-        'from': search_args.page * PAGE_SIZE,
-        'size': PAGE_SIZE,
+        'from': search_args.page * search_args.page_size,
+        'size': search_args.page_size,
     }
     text_match = {'match': {'text': search_args.q, 'doc_type': doc_type}}
     if search_args.version or search_args.regulation:

--- a/regcore_read/views/haystack_search.py
+++ b/regcore_read/views/haystack_search.py
@@ -6,7 +6,7 @@ from haystack.query import SearchQuerySet
 from regcore.db.django_models import DMLayers
 from regcore.models import Document
 from regcore.responses import success
-from regcore_read.views.search_utils import requires_search_args, PAGE_SIZE
+from regcore_read.views.search_utils import requires_search_args
 
 
 @requires_search_args
@@ -23,8 +23,8 @@ def search(request, doc_type, search_args):
     if search_args.is_subpart is not None:
         query = query.filter(is_subpart=search_args.is_subpart)
 
-    start = search_args.page * PAGE_SIZE
-    end = start + PAGE_SIZE
+    start = search_args.page * search_args.page_size
+    end = start + search_args.page_size
 
     return success({
         'total_hits': len(query),

--- a/regcore_read/views/search_utils.py
+++ b/regcore_read/views/search_utils.py
@@ -1,10 +1,12 @@
 from collections import namedtuple
 from functools import wraps
 
-from webargs import fields, ValidationError
+from webargs import fields, validate, ValidationError
 from webargs.djangoparser import parser
 
 from regcore.responses import user_error
+
+MAX_PAGE_SIZE = 50
 
 search_args = {
     'q': fields.Str(required=True),
@@ -12,12 +14,14 @@ search_args = {
     'regulation': fields.Str(missing=None),
     'is_root': fields.Bool(missing=None),
     'is_subpart': fields.Bool(missing=None),
-    'page': fields.Int(missing=0)
+    'page': fields.Int(missing=0),
+    'page_size': fields.Int(missing=MAX_PAGE_SIZE,
+                            validate=validate.Range(1, MAX_PAGE_SIZE)),
 }
-SearchArgs = namedtuple('SearchArgs', ['q', 'version', 'regulation',
-                                       'is_root', 'is_subpart', 'page'])
-
-PAGE_SIZE = 50
+SearchArgs = namedtuple(
+    'SearchArgs',
+    ['q', 'version', 'regulation', 'is_root', 'is_subpart', 'page',
+     'page_size'])
 
 
 def requires_search_args(view):


### PR DESCRIPTION
The UI shows only ten search results per page, yet the backend allows 50. This
creates a mismatch when paging. To resolve, allow the user to request a
specific page size (within bounds).