### PR TITLE
Account for more corner cases w/ section search.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy"
 install:
   - pip install coveralls tox-travis
 script:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository is part of a larger project. To read about it, please see
 ## Requirements
 
 This library requires
-* Python 2.7 (including PyPy), 3.4, 3.5, or 3.6
+* Python 2.7, 3.4, 3.5, or 3.6
 * Django 1.8, 1.9, 1.10, or 1.11
 
 ## API Docs

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="regcore",
-    version="4.0.0",
+    version="4.1.0",
     license="public domain",
     packages=find_packages(),
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean,py{27,34,35,36,py}-django{18,19,110,111}-{elastic,haystack},py{27,34,35,36}-django{110,111}-pgsql,lint,docs
+envlist = clean,py{27,34,35,36}-django{18,19,110,111}-{elastic,haystack},py{27,34,35,36}-django{110,111}-pgsql,lint,docs
 
 [testenv]
 deps =


### PR DESCRIPTION
Case 1: A search matches a node's title, but the node doesn't have text. In
this situation, we return text for the first child of that node.

Case 2: A search which matches a section, but none of its paragraphs contain
all of the search term. Here, we return text for the first child of the
section.