### PR TITLE
Allow pgsql filter threshold to be configured.

### DIFF
--- a/regcore/settings/base.py
+++ b/regcore/settings/base.py
@@ -79,6 +79,9 @@ SEARCH_HANDLER = 'regcore_read.views.haystack_search.search'
 # hitting SQLite limits
 BATCH_SIZE = 50
 
+# Lower bound for search results to appear when using pgsql search
+PG_SEARCH_RANK_CUTOFF = 0.15
+
 _envvars = ('HTTP_AUTH_USER', 'HTTP_AUTH_PASSWORD')
 for var in _envvars:
     globals()[var] = os.environ.get(var)

--- a/regcore_pgsql/tests/views_tests.py
+++ b/regcore_pgsql/tests/views_tests.py
@@ -16,10 +16,11 @@ def make_queryset_mock():
     return queryset_mock
 
 
-def test_matching_sections(monkeypatch):
+def test_matching_sections(monkeypatch, settings):
     """Search arguments should be converted to the correct arguments."""
     queryset_mock = make_queryset_mock()
     monkeypatch.setattr(views.Document, 'objects', queryset_mock)
+    settings.PG_SEARCH_RANK_CUTOFF = 0.1234
 
     result = views.matching_sections(SearchArgs(
         q='some terms', version='vvv', regulation='rrr',
@@ -29,6 +30,7 @@ def test_matching_sections(monkeypatch):
     assert 'some terms' in str(queryset_mock.annotate.call_args)
     assert 'search_vector' in str(queryset_mock.annotate.call_args)
     filters = queryset_mock.filter.call_args_list
+    assert call(rank__gt=0.1234) in filters
     assert call(version='vvv') in filters
     assert call(documentindex__doc_root='rrr') in filters
 

--- a/regcore_pgsql/views.py
+++ b/regcore_pgsql/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.postgres.search import SearchRank, SearchQuery
 from django.db.models import F, Q
 
@@ -11,7 +12,7 @@ def matching_sections(search_args):
     sections_query = Document.objects\
         .annotate(rank=SearchRank(
             F('documentindex__search_vector'), SearchQuery(search_args.q)))\
-        .filter(rank__gte=0.15)\
+        .filter(rank__gt=settings.PG_SEARCH_RANK_CUTOFF)\
         .order_by('-rank')
 
     if search_args.version:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="regcore",
-    version="4.1.0",
+    version="4.2.0",
     license="public domain",
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
This threshold depends on the documents we're searching. It'd be helpful to
allow an agency implementation to show all matches, for example.